### PR TITLE
feat(redaction): add event-level RedactEvent hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,26 @@ shutdown, err := agentcat.Track(s, "proj_YOUR_PROJECT_ID", &agentcat.Options{
 })
 ```
 
+For redaction decisions that need more context than a single string — such as which tool was called or what type of event is being published — use the event-level `RedactEvent` hook. It receives the full event object and returns a modified event, or `nil` to drop the event entirely. It can be combined with `RedactSensitiveInformation`.
+
+```go
+shutdown, err := agentcat.Track(s, "proj_YOUR_PROJECT_ID", &agentcat.Options{
+    RedactEvent: func(event *agentcat.Event) (*agentcat.Event, error) {
+        // Drop events from tools that handle secrets entirely
+        if event.GetResourceName() == "get_credentials" {
+            return nil, nil
+        }
+        // Strip response payloads from a specific tool
+        if event.GetResourceName() == "export_report" {
+            event.Response = nil
+        }
+        return event, nil
+    },
+})
+```
+
+When both hooks are configured, `RedactEvent` runs first and sees the raw, unredacted values; `RedactSensitiveInformation` then runs on its output as a final string-level scrub. The system-managed fields `Id`, `SessionId`, `ProjectId`, `EventType`, and `Timestamp` cannot be changed by the hook, and if the hook returns an error or panics, the event is dropped.
+
 ### Telemetry Exporters
 
 Send every captured event to your existing observability stack — in addition to (or instead of) the AgentCat platform. Four exporters are available: `otlp`, `datadog`, `sentry`, and `posthog`. Exporters run fire-and-forget in parallel with the AgentCat API send; an exporter failure never affects your server or the other exporters.
@@ -227,6 +247,7 @@ Diagnostics are on by default and can be turned off completely with either:
 | `DisableToolCallContext` | `bool` | `false` | When `true`, prevents the `context` parameter from being injected on tool calls |
 | `Debug` | `bool` | `false` | Enable debug logging to `~/agentcat.log` |
 | `RedactSensitiveInformation` | `func(string) string` | `nil` | Custom redaction applied to all text data before sending |
+| `RedactEvent` | `func(*Event) (*Event, error)` | `nil` | Event-level redaction hook; rewrite the full event or return `nil` to drop it |
 | `Identify` | callback | `nil` | Runs on every auto-captured event to attach user information to sessions; publishes an `agentcat:identify` event whenever it returns a non-nil identity |
 | `Hooks` | `*server.Hooks` | `nil` | Pre-existing hooks to merge with (mcp-go only) |
 | `Exporters` | `map[string]ExporterConfig` | `nil` | Telemetry exporters (`otlp`, `datadog`, `sentry`, `posthog`); with at least one exporter, the project ID may be empty (telemetry-only mode) |

--- a/custom_event.go
+++ b/custom_event.go
@@ -113,17 +113,19 @@ func PublishCustomEvent(serverOrSessionID any, projectID string, data *CustomEve
 	// For tracked servers, reuse the server's redaction, API base URL, and
 	// exporter configuration.
 	var redactFn RedactFunc
+	var redactEventFn RedactEventFunc
 	var exporterConfigs map[string]ExporterConfig
 	apiBaseURL := ResolveAPIBaseURL("")
 	if instance != nil && instance.Options != nil {
 		redactFn = instance.Options.RedactSensitiveInformation
+		redactEventFn = instance.Options.RedactEvent
 		exporterConfigs = instance.Options.Exporters
 		if instance.Options.APIBaseURL != "" {
 			apiBaseURL = instance.Options.APIBaseURL
 		}
 	}
 
-	pub := publisher.GetOrInit(redactFn, apiBaseURL, exporterConfigs)
+	pub := publisher.GetOrInit(redactFn, redactEventFn, apiBaseURL, exporterConfigs)
 	pub.Publish(evt)
 
 	logging.New().Debugf("Published custom event for session %s with type %q", sessionID, CustomEventType)

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -22,6 +22,11 @@ type UserIdentity struct {
 // RedactFunc redacts sensitive information from text before it is sent upstream
 type RedactFunc func(text string) string
 
+// RedactEventFunc is the event-level redaction hook. It receives the full
+// event before it is published and returns a modified event, or nil to drop
+// the event entirely. A non-nil error also drops the event and is logged.
+type RedactEventFunc func(event *Event) (*Event, error)
+
 // Exporter is an interface for telemetry exporters that forward events
 // to external systems.
 type Exporter interface {
@@ -105,6 +110,16 @@ type Options struct {
 
 	// RedactSensitiveInformation redacts sensitive data before sending to AgentCat.
 	RedactSensitiveInformation RedactFunc
+
+	// RedactEvent is the event-level redaction hook, invoked with the full
+	// event (inspect ResourceName, EventType, Parameters, Response, etc.)
+	// before it is published. Return a modified event, or nil to drop the
+	// event entirely. Runs before RedactSensitiveInformation, so it sees
+	// raw, unredacted values. The system-managed fields Id, SessionId,
+	// ProjectId, EventType, and Timestamp cannot be changed. If the hook
+	// returns an error or panics, the event is dropped and the error is
+	// logged.
+	RedactEvent RedactEventFunc
 
 	// Exporters configure telemetry exporters to send events to external systems.
 	// Available exporters: otlp, datadog, sentry, posthog.

--- a/internal/publisher/api_base_url_test.go
+++ b/internal/publisher/api_base_url_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestNew_APIBaseURL(t *testing.T) {
 	t.Run("uses default URL when apiBaseURL is empty", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 		defer p.Shutdown(context.Background())
 
 		if p == nil {
@@ -28,7 +28,7 @@ func TestNew_APIBaseURL(t *testing.T) {
 
 	t.Run("uses custom URL when apiBaseURL is provided", func(t *testing.T) {
 		customURL := "https://custom.api.example.com"
-		p := New(nil, customURL, nil)
+		p := New(nil, nil, customURL, nil)
 		defer p.Shutdown(context.Background())
 
 		if p == nil {
@@ -52,7 +52,7 @@ func TestGetOrInit_APIBaseURL(t *testing.T) {
 
 	t.Run("passes custom URL through to New", func(t *testing.T) {
 		customURL := "https://custom.getinit.example.com"
-		p := GetOrInit(nil, customURL, nil)
+		p := GetOrInit(nil, nil, customURL, nil)
 		defer ShutdownGlobal(context.Background())
 
 		if p == nil {

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -26,11 +26,11 @@ var (
 // configs are provided and the publisher already exists, its telemetry
 // manager is replaced (mirroring the TypeScript SDK, where track() installs a
 // fresh TelemetryManager on the shared event queue).
-func GetOrInit(redactFn core.RedactFunc, apiBaseURL string, exporterConfigs map[string]core.ExporterConfig) *Publisher {
+func GetOrInit(redactFn core.RedactFunc, redactEventFn core.RedactEventFunc, apiBaseURL string, exporterConfigs map[string]core.ExporterConfig) *Publisher {
 	globalMu.Lock()
 	defer globalMu.Unlock()
 	if globalPub == nil {
-		globalPub = New(redactFn, apiBaseURL, exporterConfigs)
+		globalPub = New(redactFn, redactEventFn, apiBaseURL, exporterConfigs)
 	} else if len(exporterConfigs) > 0 {
 		globalPub.SetTelemetryManager(exporters.NewManager(exporterConfigs))
 	}
@@ -54,15 +54,16 @@ func ShutdownGlobal(ctx context.Context) error {
 // Publisher handles asynchronous event publishing to the AgentCat API and
 // fan-out to configured telemetry exporters.
 type Publisher struct {
-	queue        chan *core.Event
-	apiClient    *agentcatapi.APIClient
-	logger       *logging.Logger
-	redactFn     core.RedactFunc
-	wg           sync.WaitGroup
-	closeMu      sync.Mutex
-	closed       bool
-	shutdownCh   chan struct{}
-	shutdownOnce sync.Once
+	queue         chan *core.Event
+	apiClient     *agentcatapi.APIClient
+	logger        *logging.Logger
+	redactFn      core.RedactFunc
+	redactEventFn core.RedactEventFunc
+	wg            sync.WaitGroup
+	closeMu       sync.Mutex
+	closed        bool
+	shutdownCh    chan struct{}
+	shutdownOnce  sync.Once
 
 	// telemetry fans events out to configured exporters. It is replaceable at
 	// runtime (see GetOrInit) and may be nil when no exporters are configured.
@@ -79,7 +80,7 @@ type Publisher struct {
 
 // New creates a new Publisher instance and starts worker goroutines.
 // If apiBaseURL is empty, the default AgentCat API URL is used.
-func New(redactFn core.RedactFunc, apiBaseURL string, exporterConfigs map[string]core.ExporterConfig) *Publisher {
+func New(redactFn core.RedactFunc, redactEventFn core.RedactEventFunc, apiBaseURL string, exporterConfigs map[string]core.ExporterConfig) *Publisher {
 	logger := logging.New()
 
 	baseURL := DefaultAPIBaseURL
@@ -98,12 +99,13 @@ func New(redactFn core.RedactFunc, apiBaseURL string, exporterConfigs map[string
 	apiClient := agentcatapi.NewAPIClient(cfg)
 
 	p := &Publisher{
-		queue:      make(chan *core.Event, QueueSize),
-		apiClient:  apiClient,
-		logger:     logger,
-		redactFn:   redactFn,
-		shutdownCh: make(chan struct{}),
-		maxRetries: MaxRetries,
+		queue:         make(chan *core.Event, QueueSize),
+		apiClient:     apiClient,
+		logger:        logger,
+		redactFn:      redactFn,
+		redactEventFn: redactEventFn,
+		shutdownCh:    make(chan struct{}),
+		maxRetries:    MaxRetries,
 	}
 	p.sendFn = p.sendEvent
 
@@ -162,6 +164,19 @@ func (p *Publisher) SetTelemetryManager(m *exporters.Manager) {
 // 4s). Retries are interrupted by shutdown. Events without a project ID
 // (telemetry-only mode) go to exporters only and skip the API send.
 func (p *Publisher) publishEvent(event *core.Event, workerID int) {
+	if p.redactEventFn != nil {
+		kept, err := redaction.ApplyEventRedaction(event, p.redactEventFn)
+		if err != nil {
+			p.logger.Warnf("Worker %d failed to redact event %s (event-level hook), dropping event: %v",
+				workerID, event.GetId(), err)
+			return
+		}
+		if !kept {
+			p.logger.Debugf("Worker %d event %s dropped by RedactEvent hook", workerID, event.GetId())
+			return
+		}
+	}
+
 	if p.redactFn != nil {
 		err := redaction.RedactEvent(event, p.redactFn)
 		if err != nil {
@@ -266,21 +281,26 @@ func (p *Publisher) Publish(event *core.Event) bool {
 		return false
 	}
 
+	// Capture the id before enqueueing: once the event is handed to the queue
+	// a worker owns it (and may rewrite it via the event-level redaction
+	// hook), so the producer must not read it afterwards.
+	eventID := event.GetId()
+
 	p.closeMu.Lock()
 	if p.closed {
 		p.closeMu.Unlock()
-		p.logger.Warnf("Publish rejected (shutting down), dropping event %s", event.GetId())
+		p.logger.Warnf("Publish rejected (shutting down), dropping event %s", eventID)
 		return false
 	}
 
 	select {
 	case p.queue <- event:
 		p.closeMu.Unlock()
-		p.logger.Debugf("Event %s enqueued for publishing", event.GetId())
+		p.logger.Debugf("Event %s enqueued for publishing", eventID)
 		return true
 	default:
 		p.closeMu.Unlock()
-		p.logger.Warnf("Queue full, dropping event %s", event.GetId())
+		p.logger.Warnf("Queue full, dropping event %s", eventID)
 		return false
 	}
 }

--- a/internal/publisher/publisher_test.go
+++ b/internal/publisher/publisher_test.go
@@ -2,6 +2,9 @@ package publisher
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -19,7 +22,7 @@ func strPtr(s string) *string {
 
 func TestNew(t *testing.T) {
 	t.Run("creates publisher with default configuration", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 		defer p.Shutdown(context.Background())
 
 		if p == nil {
@@ -44,7 +47,7 @@ func TestNew(t *testing.T) {
 
 	t.Run("creates publisher with redact function", func(t *testing.T) {
 		redactFn := func(s string) string { return "***" }
-		p := New(redactFn, "", nil)
+		p := New(redactFn, nil, "", nil)
 		defer p.Shutdown(context.Background())
 
 		if p.redactFn == nil {
@@ -53,7 +56,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("starts workers", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 		defer p.Shutdown(context.Background())
 
 		time.Sleep(50 * time.Millisecond)
@@ -74,7 +77,7 @@ func TestNew(t *testing.T) {
 
 func TestPublish(t *testing.T) {
 	t.Run("successfully enqueues event", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 		defer p.Shutdown(context.Background())
 
 		event := &core.Event{
@@ -97,7 +100,7 @@ func TestPublish(t *testing.T) {
 	})
 
 	t.Run("handles nil event gracefully", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 		defer p.Shutdown(context.Background())
 
 		ok := p.Publish(nil)
@@ -131,7 +134,7 @@ func TestPublish(t *testing.T) {
 	})
 
 	t.Run("rejects events after shutdown", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 		p.Shutdown(context.Background())
 
 		ok := p.Publish(makeEvent("after.shutdown"))
@@ -141,7 +144,7 @@ func TestPublish(t *testing.T) {
 	})
 
 	t.Run("handles concurrent publishing", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 		defer p.Shutdown(context.Background())
 
 		var wg sync.WaitGroup
@@ -165,7 +168,7 @@ func TestPublish(t *testing.T) {
 
 func TestPublishEvent(t *testing.T) {
 	t.Run("does not panic on publish", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 		p.maxRetries = 0 // avoid retry backoff against the real API in tests
 		defer p.Shutdown(context.Background())
 
@@ -184,7 +187,7 @@ func TestPublishEvent(t *testing.T) {
 				return "***"
 			}
 			return s
-		}, "", nil)
+		}, nil, "", nil)
 		p.maxRetries = 0
 		defer p.Shutdown(context.Background())
 
@@ -207,7 +210,7 @@ func TestPublishEvent(t *testing.T) {
 	t.Run("handles redaction errors gracefully", func(t *testing.T) {
 		p := New(func(s string) string {
 			panic("redaction panic")
-		}, "", nil)
+		}, nil, "", nil)
 		p.maxRetries = 0
 		defer p.Shutdown(context.Background())
 
@@ -233,8 +236,122 @@ func TestPublishEvent(t *testing.T) {
 		}
 	})
 
+	t.Run("event-level hook runs before string redaction and composes", func(t *testing.T) {
+		var rawSeen string
+		p := New(
+			func(s string) string {
+				if s == "raw secret (reviewed)" {
+					return "[STRING-REDACTED]"
+				}
+				return s
+			},
+			func(e *core.Event) (*core.Event, error) {
+				rawSeen = e.Parameters["data"].(string)
+				modified := *e
+				modified.Parameters = map[string]any{"data": rawSeen + " (reviewed)"}
+				return &modified, nil
+			},
+			"", nil)
+		defer p.Shutdown(context.Background())
+
+		event := &core.Event{
+			PublishEventRequest: agentcatapi.PublishEventRequest{
+				EventType: strPtr("test.hook.order"),
+				Parameters: map[string]any{
+					"data": "raw secret",
+				},
+			},
+		}
+
+		p.publishEvent(event, 0)
+
+		if rawSeen != "raw secret" {
+			t.Errorf("event hook saw %q, want the raw pre-redaction value", rawSeen)
+		}
+		if got := event.Parameters["data"]; got != "[STRING-REDACTED]" {
+			t.Errorf("Parameters[data] = %v, want string redaction applied to the hook's output", got)
+		}
+	})
+
+	t.Run("event-level hook returning nil drops the event before send", func(t *testing.T) {
+		var requests int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&requests, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}))
+		defer srv.Close()
+
+		p := New(nil, func(e *core.Event) (*core.Event, error) {
+			return nil, nil
+		}, srv.URL, nil)
+		defer p.Shutdown(context.Background())
+
+		event := &core.Event{
+			PublishEventRequest: agentcatapi.PublishEventRequest{
+				EventType: strPtr("test.hook.drop"),
+				ProjectId: "proj_test",
+			},
+		}
+
+		p.publishEvent(event, 0)
+
+		if n := atomic.LoadInt32(&requests); n != 0 {
+			t.Errorf("API received %d requests, want 0 (event dropped)", n)
+		}
+	})
+
+	t.Run("event-level hook error drops the event before send", func(t *testing.T) {
+		var requests int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&requests, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}))
+		defer srv.Close()
+
+		p := New(nil, func(e *core.Event) (*core.Event, error) {
+			return nil, errors.New("hook failure")
+		}, srv.URL, nil)
+		defer p.Shutdown(context.Background())
+
+		event := &core.Event{
+			PublishEventRequest: agentcatapi.PublishEventRequest{
+				EventType: strPtr("test.hook.error"),
+				ProjectId: "proj_test",
+			},
+		}
+
+		p.publishEvent(event, 0)
+
+		if n := atomic.LoadInt32(&requests); n != 0 {
+			t.Errorf("API received %d requests, want 0 (event dropped)", n)
+		}
+	})
+
+	t.Run("event-level hook panic drops the event without crashing", func(t *testing.T) {
+		p := New(nil, func(e *core.Event) (*core.Event, error) {
+			panic("hook exploded")
+		}, "", nil)
+		defer p.Shutdown(context.Background())
+
+		event := &core.Event{
+			PublishEventRequest: agentcatapi.PublishEventRequest{
+				EventType: strPtr("test.hook.panic"),
+			},
+		}
+
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("publishEvent panicked: %v", r)
+			}
+		}()
+
+		p.publishEvent(event, 0)
+	})
+
 	t.Run("handles API errors without panicking", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 		p.maxRetries = 0
 		defer p.Shutdown(context.Background())
 
@@ -254,7 +371,7 @@ func TestPublishEvent(t *testing.T) {
 	})
 
 	t.Run("respects context timeout", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 		p.maxRetries = 0
 		defer p.Shutdown(context.Background())
 
@@ -280,7 +397,7 @@ func TestPublishEvent(t *testing.T) {
 
 func TestShutdown(t *testing.T) {
 	t.Run("shuts down cleanly with empty queue", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 
 		if err := p.Shutdown(context.Background()); err != nil {
 			t.Errorf("Shutdown returned error: %v", err)
@@ -294,7 +411,7 @@ func TestShutdown(t *testing.T) {
 	})
 
 	t.Run("drains queue before shutdown completes", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 
 		for i := 0; i < 5; i++ {
 			p.Publish(makeEvent("test.shutdown"))
@@ -336,7 +453,7 @@ func TestShutdown(t *testing.T) {
 	})
 
 	t.Run("can be called multiple times safely", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 
 		p.Shutdown(context.Background())
 		p.Shutdown(context.Background())
@@ -344,7 +461,7 @@ func TestShutdown(t *testing.T) {
 	})
 
 	t.Run("rejects new events after shutdown", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 		p.Shutdown(context.Background())
 
 		ok := p.Publish(makeEvent("test.after.shutdown"))
@@ -356,7 +473,7 @@ func TestShutdown(t *testing.T) {
 
 func TestWorker(t *testing.T) {
 	t.Run("processes events from queue", func(t *testing.T) {
-		p := New(nil, "", nil)
+		p := New(nil, nil, "", nil)
 		defer p.Shutdown(context.Background())
 
 		p.Publish(makeEvent("test.worker"))
@@ -536,14 +653,14 @@ func TestGetOrInit_Resettable(t *testing.T) {
 	globalPub = nil
 	globalMu.Unlock()
 
-	p1 := GetOrInit(nil, "", nil)
+	p1 := GetOrInit(nil, nil, "", nil)
 	if p1 == nil {
 		t.Fatal("GetOrInit returned nil")
 	}
 
 	ShutdownGlobal(context.Background())
 
-	p2 := GetOrInit(nil, "", nil)
+	p2 := GetOrInit(nil, nil, "", nil)
 	if p2 == nil {
 		t.Fatal("GetOrInit returned nil after reset")
 	}
@@ -562,7 +679,7 @@ func TestQueueSizeIncreased(t *testing.T) {
 }
 
 func TestPublishEvent_RetriesFailedSends(t *testing.T) {
-	p := New(nil, "", nil)
+	p := New(nil, nil, "", nil)
 	defer p.Shutdown(context.Background())
 
 	var attempts int64
@@ -589,7 +706,7 @@ func TestPublishEvent_GivesUpAfterMaxRetries(t *testing.T) {
 		t.Skip("skipping backoff test in -short mode")
 	}
 
-	p := New(nil, "", nil)
+	p := New(nil, nil, "", nil)
 	defer p.Shutdown(context.Background())
 
 	var attempts int64
@@ -606,7 +723,7 @@ func TestPublishEvent_GivesUpAfterMaxRetries(t *testing.T) {
 }
 
 func TestPublishEvent_RetryInterruptedByShutdown(t *testing.T) {
-	p := New(nil, "", nil)
+	p := New(nil, nil, "", nil)
 
 	var attempts int64
 	p.sendFn = func(event *core.Event, workerID int) bool {
@@ -636,7 +753,7 @@ func TestPublishEvent_RetryInterruptedByShutdown(t *testing.T) {
 }
 
 func TestPublishEvent_AppliesSanitization(t *testing.T) {
-	p := New(nil, "", nil)
+	p := New(nil, nil, "", nil)
 	defer p.Shutdown(context.Background())
 
 	var sent *core.Event
@@ -664,7 +781,7 @@ func TestPublishEvent_AppliesSanitization(t *testing.T) {
 }
 
 func TestPublishEvent_AppliesTruncation(t *testing.T) {
-	p := New(nil, "", nil)
+	p := New(nil, nil, "", nil)
 	defer p.Shutdown(context.Background())
 
 	var sent *core.Event
@@ -696,7 +813,7 @@ func TestPublishEvent_PipelineOrderRedactSanitizeTruncate(t *testing.T) {
 			return strings.Repeat("x", 5000)
 		}
 		return s
-	}, "", nil)
+	}, nil, "", nil)
 	defer p.Shutdown(context.Background())
 
 	var sent *core.Event

--- a/internal/publisher/safety_test.go
+++ b/internal/publisher/safety_test.go
@@ -19,7 +19,7 @@ import (
 // same worker keeps processing later events. Without the recovery this test
 // crashes the whole test process.
 func TestWorker_SurvivesPanicWhileSending(t *testing.T) {
-	p := New(nil, "http://localhost:0", nil)
+	p := New(nil, nil, "http://localhost:0", nil)
 	p.maxRetries = 0
 	defer p.Shutdown(context.Background())
 
@@ -70,7 +70,7 @@ func TestPublishEvent_HostileParameters(t *testing.T) {
 		"normal":   "keep-me",
 	}
 
-	p := New(func(s string) string { return s }, "http://localhost:0", nil)
+	p := New(func(s string) string { return s }, nil, "http://localhost:0", nil)
 	p.maxRetries = 0
 	defer p.Shutdown(context.Background())
 
@@ -115,7 +115,7 @@ func TestShutdown_HangingExporterBoundedByDeadline(t *testing.T) {
 		srv.Close()
 	}()
 
-	p := New(nil, "http://localhost:0", map[string]core.ExporterConfig{
+	p := New(nil, nil, "http://localhost:0", map[string]core.ExporterConfig{
 		"hang": {Type: "otlp", Endpoint: srv.URL},
 	})
 	p.maxRetries = 0

--- a/internal/publisher/telemetry_test.go
+++ b/internal/publisher/telemetry_test.go
@@ -38,7 +38,7 @@ func waitForHits(t *testing.T, hits *atomic.Int64, n int64, timeout time.Duratio
 func TestPublishEvent_FansOutToExportersAlongsideAPISend(t *testing.T) {
 	srv, hits := newTelemetryTestServer(t)
 
-	p := New(nil, "", map[string]core.ExporterConfig{
+	p := New(nil, nil, "", map[string]core.ExporterConfig{
 		"otlp": {Type: "otlp", Endpoint: srv.URL},
 	})
 	defer p.Shutdown(context.Background())
@@ -60,7 +60,7 @@ func TestPublishEvent_FansOutToExportersAlongsideAPISend(t *testing.T) {
 func TestPublishEvent_TelemetryOnlySkipsAPISend(t *testing.T) {
 	srv, hits := newTelemetryTestServer(t)
 
-	p := New(nil, "", map[string]core.ExporterConfig{
+	p := New(nil, nil, "", map[string]core.ExporterConfig{
 		"otlp": {Type: "otlp", Endpoint: srv.URL},
 	})
 	defer p.Shutdown(context.Background())
@@ -87,7 +87,7 @@ func TestPublishEvent_ExporterFailureDoesNotAffectAPISend(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := New(nil, "", map[string]core.ExporterConfig{
+	p := New(nil, nil, "", map[string]core.ExporterConfig{
 		"otlp": {Type: "otlp", Endpoint: srv.URL},
 	})
 	defer p.Shutdown(context.Background())
@@ -110,13 +110,13 @@ func TestGetOrInit_ReplacesTelemetryManagerOnExistingPublisher(t *testing.T) {
 	ShutdownGlobal(context.Background())
 	t.Cleanup(func() { ShutdownGlobal(context.Background()) })
 
-	p1 := GetOrInit(nil, "", nil)
+	p1 := GetOrInit(nil, nil, "", nil)
 	if p1.telemetry.Load() != nil {
 		t.Fatal("expected no telemetry manager without exporter configs")
 	}
 
 	srv, hits := newTelemetryTestServer(t)
-	p2 := GetOrInit(nil, "", map[string]core.ExporterConfig{
+	p2 := GetOrInit(nil, nil, "", map[string]core.ExporterConfig{
 		"otlp": {Type: "otlp", Endpoint: srv.URL},
 	})
 	if p2 != p1 {

--- a/internal/redaction/redact_event_hook_test.go
+++ b/internal/redaction/redact_event_hook_test.go
@@ -1,0 +1,197 @@
+package redaction
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	agentcatapi "go.agentcat.com/api"
+	"go.agentcat.com/sdk/internal/core"
+)
+
+func baseEvent() *core.Event {
+	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	req := agentcatapi.PublishEventRequest{
+		Id:           core.Ptr("evt_original"),
+		ProjectId:    "proj_789",
+		EventType:    core.Ptr("mcp:tools/call"),
+		Timestamp:    &ts,
+		ResourceName: core.Ptr("add_todo"),
+		UserIntent:   core.Ptr("sensitive intent"),
+		Parameters:   map[string]any{"text": "sensitive text"},
+		Response:     map[string]any{"content": "sensitive response"},
+	}
+	req.SetSessionId("ses_123")
+	return &core.Event{PublishEventRequest: req}
+}
+
+func TestApplyEventRedaction_RewriteInPlace(t *testing.T) {
+	event := baseEvent()
+	observer := event // e.g. a capture holding the pointer before processing
+
+	kept, err := ApplyEventRedaction(event, func(e *core.Event) (*core.Event, error) {
+		modified := *e
+		modified.Parameters = map[string]any{"text": "[SCRUBBED]"}
+		return &modified, nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !kept {
+		t.Fatal("kept = false, want true")
+	}
+	if got := event.Parameters["text"]; got != "[SCRUBBED]" {
+		t.Errorf("Parameters[text] = %v, want [SCRUBBED]", got)
+	}
+	if got := event.Response["content"]; got != "sensitive response" {
+		t.Errorf("Response[content] = %v, want unchanged", got)
+	}
+	// The original pointer must observe the rewrite
+	if got := observer.Parameters["text"]; got != "[SCRUBBED]" {
+		t.Errorf("observer pointer did not see the rewrite: %v", got)
+	}
+}
+
+func TestApplyEventRedaction_NilResultDropsEvent(t *testing.T) {
+	event := baseEvent()
+
+	kept, err := ApplyEventRedaction(event, func(e *core.Event) (*core.Event, error) {
+		return nil, nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if kept {
+		t.Fatal("kept = true, want false (drop)")
+	}
+	// The event is left untouched on drop
+	if got := event.Parameters["text"]; got != "sensitive text" {
+		t.Errorf("dropped event was mutated: %v", got)
+	}
+}
+
+func TestApplyEventRedaction_ErrorDropsEvent(t *testing.T) {
+	event := baseEvent()
+
+	kept, err := ApplyEventRedaction(event, func(e *core.Event) (*core.Event, error) {
+		return nil, errors.New("hook failure")
+	})
+
+	if err == nil || err.Error() != "hook failure" {
+		t.Fatalf("err = %v, want hook failure", err)
+	}
+	if kept {
+		t.Fatal("kept = true, want false")
+	}
+}
+
+func TestApplyEventRedaction_PanicBecomesError(t *testing.T) {
+	event := baseEvent()
+
+	kept, err := ApplyEventRedaction(event, func(e *core.Event) (*core.Event, error) {
+		panic("hook exploded")
+	})
+
+	if err == nil {
+		t.Fatal("err = nil, want panic converted to error")
+	}
+	if kept {
+		t.Fatal("kept = true, want false")
+	}
+}
+
+func TestApplyEventRedaction_RestoresSystemManagedFields(t *testing.T) {
+	event := baseEvent()
+
+	kept, err := ApplyEventRedaction(event, func(e *core.Event) (*core.Event, error) {
+		modified := *e
+		modified.Id = core.Ptr("evt_forged")
+		modified.SetSessionId("ses_forged")
+		modified.ProjectId = "proj_forged"
+		modified.EventType = core.Ptr("forged:event")
+		modified.Timestamp = nil
+		return &modified, nil
+	})
+
+	if err != nil || !kept {
+		t.Fatalf("kept=%v err=%v, want kept with no error", kept, err)
+	}
+	if got := event.GetId(); got != "evt_original" {
+		t.Errorf("Id = %q, want evt_original", got)
+	}
+	if got := event.GetSessionId(); got != "ses_123" {
+		t.Errorf("SessionId = %q, want ses_123", got)
+	}
+	if event.ProjectId != "proj_789" {
+		t.Errorf("ProjectId = %q, want proj_789", event.ProjectId)
+	}
+	if got := event.GetEventType(); got != "mcp:tools/call" {
+		t.Errorf("EventType = %q, want mcp:tools/call", got)
+	}
+	if event.Timestamp == nil {
+		t.Error("Timestamp was cleared, want restored")
+	}
+}
+
+func TestApplyEventRedaction_HonorsClearedFields(t *testing.T) {
+	event := baseEvent()
+
+	kept, err := ApplyEventRedaction(event, func(e *core.Event) (*core.Event, error) {
+		modified := *e
+		modified.Response = nil
+		modified.UserIntent = nil
+		return &modified, nil
+	})
+
+	if err != nil || !kept {
+		t.Fatalf("kept=%v err=%v, want kept with no error", kept, err)
+	}
+	if event.Response != nil {
+		t.Errorf("Response = %v, want nil (cleared by hook)", event.Response)
+	}
+	if event.UserIntent != nil {
+		t.Errorf("UserIntent = %v, want nil (cleared by hook)", event.UserIntent)
+	}
+	if got := event.Parameters["text"]; got != "sensitive text" {
+		t.Errorf("Parameters[text] = %v, want unchanged", got)
+	}
+}
+
+func TestApplyEventRedaction_RestoresSystemManagedFieldsOnInPlaceMutation(t *testing.T) {
+	event := baseEvent()
+
+	kept, err := ApplyEventRedaction(event, func(e *core.Event) (*core.Event, error) {
+		// Forge system fields on the same pointer instead of a copy
+		e.ProjectId = "proj_forged"
+		e.SetSessionId("ses_forged")
+		return e, nil
+	})
+
+	if err != nil || !kept {
+		t.Fatalf("kept=%v err=%v, want kept with no error", kept, err)
+	}
+	if event.ProjectId != "proj_789" {
+		t.Errorf("ProjectId = %q, want proj_789 (restored)", event.ProjectId)
+	}
+	if got := event.GetSessionId(); got != "ses_123" {
+		t.Errorf("SessionId = %q, want ses_123 (restored)", got)
+	}
+}
+
+func TestApplyEventRedaction_SamePointerReturnIsFine(t *testing.T) {
+	event := baseEvent()
+
+	kept, err := ApplyEventRedaction(event, func(e *core.Event) (*core.Event, error) {
+		e.Parameters = map[string]any{"text": "[MUTATED]"}
+		return e, nil
+	})
+
+	if err != nil || !kept {
+		t.Fatalf("kept=%v err=%v, want kept with no error", kept, err)
+	}
+	if got := event.Parameters["text"]; got != "[MUTATED]" {
+		t.Errorf("Parameters[text] = %v, want [MUTATED]", got)
+	}
+}

--- a/internal/redaction/redactor.go
+++ b/internal/redaction/redactor.go
@@ -1,6 +1,8 @@
 package redaction
 
 import (
+	"fmt"
+
 	"go.agentcat.com/sdk/internal/core"
 	"go.agentcat.com/sdk/internal/walk"
 )
@@ -68,6 +70,63 @@ func redactValue(v any, redactFn core.RedactFunc) any {
 	return walk.Bounded(v, func(s string) any {
 		return safeRedact(s, redactFn)
 	})
+}
+
+// ApplyEventRedaction applies the customer's event-level redaction hook to an
+// event, in place. The hook receives the full event and may return a modified
+// event, or nil to drop the event entirely.
+//
+// The event object is rewritten rather than replaced: publisher workers and
+// their observers hold the same pointer across processing, so a hook that
+// returns a new event has its result copied into the original allocation,
+// which also ensures fields the hook cleared stay cleared. System-managed
+// fields are restored from the original. A panic inside the hook is converted
+// to an error (the caller drops the event, mirroring hook errors).
+//
+// Returns kept=false when the hook dropped the event (nil result), and a
+// non-nil error when the hook failed.
+func ApplyEventRedaction(event *core.Event, redactEventFn core.RedactEventFunc) (kept bool, err error) {
+	if event == nil || redactEventFn == nil {
+		return true, nil
+	}
+
+	// Snapshot system-managed fields before the hook runs — they are not
+	// consumer-settable, even by a hook that mutates the event in place
+	id := event.Id
+	sessionID := event.SessionId
+	projectID := event.ProjectId
+	eventType := event.EventType
+	timestamp := event.Timestamp
+
+	var result *core.Event
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("event redaction hook panicked: %v", r)
+			}
+		}()
+		result, err = redactEventFn(event)
+	}()
+	if err != nil {
+		return false, err
+	}
+	if result == nil {
+		return false, nil
+	}
+
+	if result != event {
+		// Copy the hook's result into the original allocation so pointer
+		// holders see the post-hook event, and cleared fields stay cleared
+		*event = *result
+	}
+
+	event.Id = id
+	event.SessionId = sessionID
+	event.ProjectId = projectID
+	event.EventType = eventType
+	event.Timestamp = timestamp
+
+	return true, nil
 }
 
 // safeRedact applies the redaction function with panic recovery

--- a/mcpcat.go
+++ b/mcpcat.go
@@ -44,8 +44,8 @@ func UnregisterServer(server any) {
 // If apiBaseURL is empty, the default AgentCat API URL is used. When exporter
 // configs are provided, every published event is also fanned out to the
 // configured telemetry exporters, independently of the AgentCat API send.
-func InitPublisher(redactFn RedactFunc, apiBaseURL string, exporterConfigs map[string]ExporterConfig) func(evt *Event) {
-	pub := publisher.GetOrInit(redactFn, apiBaseURL, exporterConfigs)
+func InitPublisher(redactFn RedactFunc, redactEventFn RedactEventFunc, apiBaseURL string, exporterConfigs map[string]ExporterConfig) func(evt *Event) {
+	pub := publisher.GetOrInit(redactFn, redactEventFn, apiBaseURL, exporterConfigs)
 	return func(evt *Event) {
 		if evt != nil {
 			pub.Publish(evt)

--- a/mcpcat_test.go
+++ b/mcpcat_test.go
@@ -56,7 +56,7 @@ func TestInitPublisher(t *testing.T) {
 	// Ensure clean state
 	publisher.ShutdownGlobal(context.Background())
 
-	publishFn := InitPublisher(nil, "", nil)
+	publishFn := InitPublisher(nil, nil, "", nil)
 	defer Shutdown(context.Background())
 
 	if publishFn == nil {
@@ -75,7 +75,7 @@ func TestInitPublisher_WithRedactFunc(t *testing.T) {
 	publisher.ShutdownGlobal(context.Background())
 
 	redactFn := func(s string) string { return "***" }
-	publishFn := InitPublisher(redactFn, "", nil)
+	publishFn := InitPublisher(redactFn, nil, "", nil)
 	defer Shutdown(context.Background())
 
 	if publishFn == nil {
@@ -86,7 +86,7 @@ func TestInitPublisher_WithRedactFunc(t *testing.T) {
 func TestShutdown(t *testing.T) {
 	publisher.ShutdownGlobal(context.Background())
 
-	_ = InitPublisher(nil, "", nil)
+	_ = InitPublisher(nil, nil, "", nil)
 
 	err := Shutdown(context.Background())
 	if err != nil {

--- a/mcpgo/mcpgo.go
+++ b/mcpgo/mcpgo.go
@@ -81,6 +81,16 @@ type Options struct {
 	// RedactSensitiveInformation redacts sensitive data before sending to AgentCat.
 	RedactSensitiveInformation func(text string) string
 
+	// RedactEvent is the event-level redaction hook, invoked with the full
+	// event (inspect ResourceName, EventType, Parameters, Response, etc.)
+	// before it is published. Return a modified event, or nil to drop the
+	// event entirely. Runs before RedactSensitiveInformation, so it sees
+	// raw, unredacted values. The system-managed fields Id, SessionId,
+	// ProjectId, EventType, and Timestamp cannot be changed. If the hook
+	// returns an error or panics, the event is dropped and the error is
+	// logged.
+	RedactEvent func(event *agentcat.Event) (*agentcat.Event, error)
+
 	// DisableDiagnostics disables AgentCat's internal SDK diagnostics. On by default;
 	// also disable via the DISABLE_DIAGNOSTICS env var. ~/agentcat.log is unaffected.
 	DisableDiagnostics bool
@@ -149,6 +159,7 @@ func Track(mcpServer *server.MCPServer, projectID string, opts *Options) (func(c
 		CustomContextDescription:   opts.CustomContextDescription,
 		Debug:                      opts.Debug,
 		RedactSensitiveInformation: opts.RedactSensitiveInformation,
+		RedactEvent:                opts.RedactEvent,
 		DisableDiagnostics:         opts.DisableDiagnostics,
 		APIBaseURL:                 apiBaseURL,
 		Exporters:                  opts.Exporters,
@@ -163,7 +174,7 @@ func Track(mcpServer *server.MCPServer, projectID string, opts *Options) (func(c
 	agentcat.RegisterServer(mcpServer, instance)
 	agentcat.SetDebug(opts.Debug)
 
-	publishFn := agentcat.InitPublisher(opts.RedactSensitiveInformation, apiBaseURL, opts.Exporters)
+	publishFn := agentcat.InitPublisher(opts.RedactSensitiveInformation, opts.RedactEvent, apiBaseURL, opts.Exporters)
 
 	sessionMap := addTracingToHooks(hooks, opts, publishFn)
 	registerGetMoreToolsIfEnabled(mcpServer, coreOpts)

--- a/mcpgo/redact_event_test.go
+++ b/mcpgo/redact_event_test.go
@@ -1,0 +1,205 @@
+package mcpgo
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	agentcat "go.agentcat.com/sdk"
+)
+
+// captureAPI is a stand-in for the AgentCat API that records raw request
+// bodies so tests can assert on exactly what would have been published.
+type captureAPI struct {
+	mu     sync.Mutex
+	bodies []string
+	srv    *httptest.Server
+}
+
+func newCaptureAPI(t *testing.T) *captureAPI {
+	t.Helper()
+	c := &captureAPI{}
+	c.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		c.mu.Lock()
+		c.bodies = append(c.bodies, string(body))
+		c.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	t.Cleanup(c.srv.Close)
+	return c
+}
+
+// waitFor polls until predicate returns true or the timeout elapses.
+func (c *captureAPI) waitFor(timeout time.Duration, predicate func(bodies []string) bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		c.mu.Lock()
+		ok := predicate(append([]string(nil), c.bodies...))
+		c.mu.Unlock()
+		if ok {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+func (c *captureAPI) snapshot() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.bodies...)
+}
+
+// resetPublisher shuts down the global publisher so the next Track call
+// creates a fresh one carrying this test's hooks and API base URL.
+func resetPublisher(t *testing.T) {
+	t.Helper()
+	_ = agentcat.Shutdown(context.Background())
+	t.Cleanup(func() {
+		_ = agentcat.Shutdown(context.Background())
+	})
+}
+
+func callToolHTTP(t *testing.T, c interface {
+	CallTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error)
+}, name string, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Name = name
+	req.Params.Arguments = args
+	result, err := c.CallTool(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CallTool(%s) failed: %v", name, err)
+	}
+	return result
+}
+
+// TestRedactEvent_HookRewritesEventBeforePublish verifies over a real HTTP
+// transport that the RedactEvent hook receives the full event with raw values
+// and that its rewrite is what reaches the API.
+func TestRedactEvent_HookRewritesEventBeforePublish(t *testing.T) {
+	resetPublisher(t)
+	api := newCaptureAPI(t)
+
+	mcpClient := setupStreamableHTTP(t, &Options{
+		DisableReportMissing:   true,
+		DisableToolCallContext: true,
+		APIBaseURL:             api.srv.URL,
+		RedactEvent: func(event *agentcat.Event) (*agentcat.Event, error) {
+			if event.GetEventType() == "mcp:tools/call" {
+				modified := *event
+				modified.Parameters = map[string]any{"replaced": true}
+				modified.Response = nil // the tool echoes its arguments back
+				return &modified, nil
+			}
+			return event, nil
+		},
+	})
+
+	result := callToolHTTP(t, mcpClient, "add_todo", map[string]any{
+		"title":       "Secret task title",
+		"description": "Sensitive description",
+	})
+	assertContains(t, resultText(result), "Added todo")
+
+	found := api.waitFor(3*time.Second, func(bodies []string) bool {
+		for _, b := range bodies {
+			if strings.Contains(b, "mcp:tools/call") {
+				return true
+			}
+		}
+		return false
+	})
+	if !found {
+		t.Fatal("no mcp:tools/call event reached the capture API")
+	}
+
+	for _, b := range api.snapshot() {
+		if strings.Contains(b, "mcp:tools/call") {
+			if !strings.Contains(b, `"replaced":true`) {
+				t.Errorf("published tool-call event does not contain the hook's rewrite: %s", b)
+			}
+			if strings.Contains(b, "Secret task title") {
+				t.Errorf("raw parameters leaked past the RedactEvent hook: %s", b)
+			}
+		}
+	}
+}
+
+// TestRedactEvent_NilDropsEvent verifies over a real HTTP transport that
+// returning nil from the hook drops the event entirely while other event
+// types still publish and the server continues to operate.
+func TestRedactEvent_NilDropsEvent(t *testing.T) {
+	resetPublisher(t)
+	api := newCaptureAPI(t)
+
+	mcpClient := setupStreamableHTTP(t, &Options{
+		DisableReportMissing:   true,
+		DisableToolCallContext: true,
+		APIBaseURL:             api.srv.URL,
+		RedactEvent: func(event *agentcat.Event) (*agentcat.Event, error) {
+			if event.GetEventType() == "mcp:tools/call" {
+				return nil, nil // drop
+			}
+			return event, nil
+		},
+	})
+
+	result := callToolHTTP(t, mcpClient, "add_todo", map[string]any{
+		"title":       "Should be dropped",
+		"description": "This event never reaches the API",
+	})
+	assertContains(t, resultText(result), "Added todo")
+
+	// Non-tool-call events (e.g. initialize) still flow, proving the pipeline
+	// is alive while tool-call events are dropped.
+	arrived := api.waitFor(3*time.Second, func(bodies []string) bool {
+		return len(bodies) > 0
+	})
+	if !arrived {
+		t.Fatal("no events at all reached the capture API")
+	}
+	time.Sleep(500 * time.Millisecond) // settle: give a dropped event time to (not) arrive
+
+	for _, b := range api.snapshot() {
+		if strings.Contains(b, "mcp:tools/call") {
+			t.Errorf("tool-call event reached the API despite nil return: %s", b)
+		}
+	}
+
+	// The server is still fully operational.
+	listResult := callToolHTTP(t, mcpClient, "list_todos", map[string]any{})
+	assertContains(t, resultText(listResult), "Should be dropped")
+}
+
+// TestRedactEvent_PanicInHookDoesNotCrashServer verifies that a panic inside
+// the RedactEvent hook drops the event but never crashes the MCP server.
+func TestRedactEvent_PanicInHookDoesNotCrashServer(t *testing.T) {
+	resetPublisher(t)
+
+	mcpClient := setupStreamableHTTP(t, &Options{
+		DisableReportMissing:   true,
+		DisableToolCallContext: true,
+		RedactEvent: func(event *agentcat.Event) (*agentcat.Event, error) {
+			panic("redact event panic!")
+		},
+	})
+
+	result1 := callToolHTTP(t, mcpClient, "add_todo", map[string]any{
+		"title":       "Secret task",
+		"description": "Contains sensitive data",
+	})
+	assertContains(t, resultText(result1), "Added todo")
+
+	// Second call — the server is still fully operational.
+	result2 := callToolHTTP(t, mcpClient, "list_todos", map[string]any{})
+	assertContains(t, resultText(result2), "Secret task")
+}

--- a/officialsdk/officialsdk.go
+++ b/officialsdk/officialsdk.go
@@ -78,6 +78,16 @@ type Options struct {
 	// RedactSensitiveInformation redacts sensitive data before sending to AgentCat.
 	RedactSensitiveInformation func(text string) string
 
+	// RedactEvent is the event-level redaction hook, invoked with the full
+	// event (inspect ResourceName, EventType, Parameters, Response, etc.)
+	// before it is published. Return a modified event, or nil to drop the
+	// event entirely. Runs before RedactSensitiveInformation, so it sees
+	// raw, unredacted values. The system-managed fields Id, SessionId,
+	// ProjectId, EventType, and Timestamp cannot be changed. If the hook
+	// returns an error or panics, the event is dropped and the error is
+	// logged.
+	RedactEvent func(event *agentcat.Event) (*agentcat.Event, error)
+
 	// DisableDiagnostics disables AgentCat's internal SDK diagnostics. On by default;
 	// also disable via the DISABLE_DIAGNOSTICS env var. ~/agentcat.log is unaffected.
 	DisableDiagnostics bool
@@ -140,6 +150,7 @@ func Track(mcpServer *mcp.Server, projectID string, opts *Options) (func(context
 		CustomContextDescription:   opts.CustomContextDescription,
 		Debug:                      opts.Debug,
 		RedactSensitiveInformation: opts.RedactSensitiveInformation,
+		RedactEvent:                opts.RedactEvent,
 		DisableDiagnostics:         opts.DisableDiagnostics,
 		APIBaseURL:                 apiBaseURL,
 		Exporters:                  opts.Exporters,
@@ -154,7 +165,7 @@ func Track(mcpServer *mcp.Server, projectID string, opts *Options) (func(context
 	agentcat.RegisterServer(mcpServer, instance)
 	agentcat.SetDebug(opts.Debug)
 
-	publishFn := agentcat.InitPublisher(opts.RedactSensitiveInformation, apiBaseURL, opts.Exporters)
+	publishFn := agentcat.InitPublisher(opts.RedactSensitiveInformation, opts.RedactEvent, apiBaseURL, opts.Exporters)
 
 	// Retrieve the server implementation for session metadata.
 	// We store a copy of the implementation info at Track() time.

--- a/officialsdk/redact_event_test.go
+++ b/officialsdk/redact_event_test.go
@@ -1,0 +1,236 @@
+package officialsdk
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	agentcat "go.agentcat.com/sdk"
+)
+
+// captureAPI is a stand-in for the AgentCat API that records raw request
+// bodies so tests can assert on exactly what would have been published.
+type captureAPI struct {
+	mu     sync.Mutex
+	bodies []string
+	srv    *httptest.Server
+}
+
+func newCaptureAPI(t *testing.T) *captureAPI {
+	t.Helper()
+	c := &captureAPI{}
+	c.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		c.mu.Lock()
+		c.bodies = append(c.bodies, string(body))
+		c.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	t.Cleanup(c.srv.Close)
+	return c
+}
+
+func (c *captureAPI) waitFor(timeout time.Duration, predicate func(bodies []string) bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		c.mu.Lock()
+		ok := predicate(append([]string(nil), c.bodies...))
+		c.mu.Unlock()
+		if ok {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+func (c *captureAPI) snapshot() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.bodies...)
+}
+
+// setupTrackedServer creates a real tracked server (real publisher, no mock)
+// connected over in-memory transports, with the global publisher reset so
+// this test's options take effect.
+func setupTrackedServer(t *testing.T, opts *Options) *mcp.ClientSession {
+	t.Helper()
+
+	_ = agentcat.Shutdown(context.Background())
+	t.Cleanup(func() {
+		_ = agentcat.Shutdown(context.Background())
+	})
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "redact-test-server", Version: "1.0.0"}, nil)
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "greet",
+		Description: "Greets a person by name",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args greetArgs) (*mcp.CallToolResult, greetResult, error) {
+		return nil, greetResult{Text: "Hello, " + args.Name + "!"}, nil
+	})
+
+	if _, err := Track(server, "test_project", opts); err != nil {
+		t.Fatalf("Track failed: %v", err)
+	}
+	t.Cleanup(func() {
+		agentcat.UnregisterServer(server)
+	})
+
+	ctx := context.Background()
+	t1, t2 := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, t1, nil)
+	if err != nil {
+		t.Fatalf("server.Connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "redact-test-client", Version: "1.0.0"}, nil)
+	clientSession, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatalf("client.Connect: %v", err)
+	}
+	t.Cleanup(func() {
+		clientSession.Close()
+		serverSession.Wait()
+	})
+
+	return clientSession
+}
+
+// TestRedactEvent_HookRewritesEventBeforePublish verifies that the RedactEvent
+// hook receives the full event with raw values and that its rewrite is what
+// reaches the API.
+func TestRedactEvent_HookRewritesEventBeforePublish(t *testing.T) {
+	api := newCaptureAPI(t)
+
+	clientSession := setupTrackedServer(t, &Options{
+		DisableReportMissing:   true,
+		DisableToolCallContext: true,
+		APIBaseURL:             api.srv.URL,
+		RedactEvent: func(event *agentcat.Event) (*agentcat.Event, error) {
+			if event.GetEventType() == "mcp:tools/call" {
+				modified := *event
+				modified.Parameters = map[string]any{"replaced": true}
+				modified.Response = nil // the tool echoes its arguments back
+				return &modified, nil
+			}
+			return event, nil
+		},
+	})
+
+	result, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "greet",
+		Arguments: map[string]any{"name": "Secret Name"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if result.IsError {
+		t.Fatal("expected tool call to succeed")
+	}
+
+	found := api.waitFor(3*time.Second, func(bodies []string) bool {
+		for _, b := range bodies {
+			if strings.Contains(b, "mcp:tools/call") {
+				return true
+			}
+		}
+		return false
+	})
+	if !found {
+		t.Fatal("no mcp:tools/call event reached the capture API")
+	}
+
+	for _, b := range api.snapshot() {
+		if strings.Contains(b, "mcp:tools/call") {
+			if !strings.Contains(b, `"replaced":true`) {
+				t.Errorf("published tool-call event does not contain the hook's rewrite: %s", b)
+			}
+			if strings.Contains(b, "Secret Name") {
+				t.Errorf("raw parameters leaked past the RedactEvent hook: %s", b)
+			}
+		}
+	}
+}
+
+// TestRedactEvent_NilDropsEvent verifies that returning nil from the hook
+// drops the event entirely while other event types still publish and the
+// server continues to operate.
+func TestRedactEvent_NilDropsEvent(t *testing.T) {
+	api := newCaptureAPI(t)
+
+	clientSession := setupTrackedServer(t, &Options{
+		DisableReportMissing:   true,
+		DisableToolCallContext: true,
+		APIBaseURL:             api.srv.URL,
+		RedactEvent: func(event *agentcat.Event) (*agentcat.Event, error) {
+			if event.GetEventType() == "mcp:tools/call" {
+				return nil, nil // drop
+			}
+			return event, nil
+		},
+	})
+
+	ctx := context.Background()
+	result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "greet",
+		Arguments: map[string]any{"name": "Dropped"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if result.IsError {
+		t.Fatal("expected tool call to succeed")
+	}
+
+	arrived := api.waitFor(3*time.Second, func(bodies []string) bool {
+		return len(bodies) > 0
+	})
+	if !arrived {
+		t.Fatal("no events at all reached the capture API")
+	}
+	time.Sleep(500 * time.Millisecond) // settle: give a dropped event time to (not) arrive
+
+	for _, b := range api.snapshot() {
+		if strings.Contains(b, "mcp:tools/call") {
+			t.Errorf("tool-call event reached the API despite nil return: %s", b)
+		}
+	}
+
+	// The server is still fully operational.
+	result2, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "greet",
+		Arguments: map[string]any{"name": "Again"},
+	})
+	if err != nil || result2.IsError {
+		t.Fatalf("second CallTool failed: err=%v", err)
+	}
+}
+
+// TestRedactEvent_PanicInHookDoesNotCrashServer verifies that a panic inside
+// the RedactEvent hook drops the event but never crashes the MCP server.
+func TestRedactEvent_PanicInHookDoesNotCrashServer(t *testing.T) {
+	clientSession := setupTrackedServer(t, &Options{
+		DisableReportMissing:   true,
+		DisableToolCallContext: true,
+		RedactEvent: func(event *agentcat.Event) (*agentcat.Event, error) {
+			panic("redact event panic!")
+		},
+	})
+
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "greet",
+			Arguments: map[string]any{"name": "World"},
+		})
+		if err != nil || result.IsError {
+			t.Fatalf("CallTool %d failed despite hook panic: err=%v", i, err)
+		}
+	}
+}

--- a/types.go
+++ b/types.go
@@ -11,6 +11,7 @@ type (
 	UserIdentity     = core.UserIdentity
 	Options          = core.Options
 	RedactFunc       = core.RedactFunc
+	RedactEventFunc  = core.RedactEventFunc
 	Exporter         = core.Exporter
 	ExporterConfig   = core.ExporterConfig
 	Event            = core.Event


### PR DESCRIPTION
## Summary

Redaction decisions often need more context than a single string. The existing `RedactSensitiveInformation` hook is applied blindly to every string field in an event, so consumers can't tell which tool produced a value, what type of event is being published, or which field a string belongs to.

This PR adds a new **event-level redaction hook**, `RedactEvent`, alongside the existing string-level hook. It receives the full `Event` object — `ResourceName`, `EventType`, `Parameters`, `Response`, `UserIntent`, and the rest — and returns a modified event, or `nil` to drop the event entirely. It is available on the core `Options` struct and on both adapter modules (`mcpgo` and `officialsdk`).

```go
shutdown, err := agentcat.Track(s, "proj_YOUR_PROJECT_ID", &agentcat.Options{
    RedactEvent: func(event *agentcat.Event) (*agentcat.Event, error) {
        // Drop events from tools that handle secrets entirely
        if event.GetResourceName() == "get_credentials" {
            return nil, nil
        }
        // Strip response payloads from a specific tool
        if event.GetResourceName() == "export_report" {
            event.Response = nil
        }
        return event, nil
    },
})
```

## Behavior

- **Signature**: `func(event *Event) (*Event, error)`, exported as `RedactEventFunc`. Return a modified event; `nil, nil` drops the event; a non-nil error also drops it and logs.
- **Ordering**: `RedactEvent` runs first in the publisher pipeline and sees raw, unredacted values with full event context. `RedactSensitiveInformation` (if configured) then runs on its output, so the string-level scrubber remains the last line of defense.
- **Drop semantics**: the event-level hook fails closed — a `nil` return, a returned error, or a panic inside the hook all drop the event and log. This intentionally differs from the string-level redactor, which fails open with `[REDACTION_ERROR]` placeholders; for a hook that can inspect and rewrite whole events, dropping is the safer failure mode.
- **System-managed fields**: `Id`, `SessionId`, `ProjectId`, `EventType`, and `Timestamp` are restored if the hook changes or removes them — including hooks that mutate the event in place — protecting session and project attribution. Everything else is fully consumer-controlled, and cleared fields stay cleared.

## Fix worth noting

`Publisher.Publish` previously read `event.GetId()` for a debug log *after* handing the event to the worker queue. With workers now able to rewrite the whole event, this surfaced as a data race under `-race`. `Publish` now captures the id before enqueueing — after handoff, the worker owns the event.

## Test plan

- [x] Unit tests for `ApplyEventRedaction`: rewrite honored through the original pointer, `nil` drops, error drops, panic converted to error, system-managed field restoration (both copy-based and in-place forgeries), cleared fields honored, same-pointer returns (`internal/redaction/redact_event_hook_test.go`)
- [x] Publisher pipeline tests: hook runs before string redaction and composes with it; `nil`/error returns drop the event before any API request (verified against an `httptest` capture server); panic containment (`internal/publisher/publisher_test.go`)
- [x] Adapter integration tests over real transports with a real publisher and an `httptest` stand-in for the AgentCat API: hook rewrites reach the API, raw values never leak, `nil` drops tool-call events while other events still publish, and a panicking hook never disrupts the MCP server (`mcpgo/redact_event_test.go`, `officialsdk/redact_event_test.go`)
- [x] `gofmt` clean, `go vet ./...` clean, `go test -race ./...` green in the root module, `mcpgo/`, and `officialsdk/`