### PR TITLE
feat: sturdier session handles — issue IDs first, structured mcp_session status

### DIFF
--- a/examples/mcpgo/advanced/go.mod
+++ b/examples/mcpgo/advanced/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/mark3labs/mcp-go v0.57.0
-	go.agentcat.com/sdk/mcpgo/v2 v2.0.0
+	go.agentcat.com/sdk/mcpgo/v2 v2.1.0
 )
 
 require (
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.agentcat.com/api v1.0.0 // indirect
-	go.agentcat.com/sdk/v2 v2.0.0 // indirect
+	go.agentcat.com/sdk/v2 v2.1.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/validator.v2 v2.0.1 // indirect
 )

--- a/examples/mcpgo/basic/go.mod
+++ b/examples/mcpgo/basic/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/mark3labs/mcp-go v0.57.0
-	go.agentcat.com/sdk/mcpgo/v2 v2.0.0
+	go.agentcat.com/sdk/mcpgo/v2 v2.1.0
 )
 
 require (
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.agentcat.com/api v1.0.0 // indirect
-	go.agentcat.com/sdk/v2 v2.0.0 // indirect
+	go.agentcat.com/sdk/v2 v2.1.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/validator.v2 v2.0.1 // indirect
 )

--- a/examples/officialsdk/advanced/go.mod
+++ b/examples/officialsdk/advanced/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0
-	go.agentcat.com/sdk/officialsdk/v2 v2.0.0
+	go.agentcat.com/sdk/officialsdk/v2 v2.1.0
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.agentcat.com/api v1.0.0 // indirect
-	go.agentcat.com/sdk/v2 v2.0.0 // indirect
+	go.agentcat.com/sdk/v2 v2.1.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/examples/officialsdk/basic/go.mod
+++ b/examples/officialsdk/basic/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0
-	go.agentcat.com/sdk/officialsdk/v2 v2.0.0
+	go.agentcat.com/sdk/officialsdk/v2 v2.1.0
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.agentcat.com/api v1.0.0 // indirect
-	go.agentcat.com/sdk/v2 v2.0.0 // indirect
+	go.agentcat.com/sdk/v2 v2.1.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/examples/officialsdk/factory/go.mod
+++ b/examples/officialsdk/factory/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0
-	go.agentcat.com/sdk/officialsdk/v2 v2.0.0
+	go.agentcat.com/sdk/officialsdk/v2 v2.1.0
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.agentcat.com/api v1.0.0 // indirect
-	go.agentcat.com/sdk/v2 v2.0.0 // indirect
+	go.agentcat.com/sdk/v2 v2.1.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -4,20 +4,17 @@
 // is the point. Do not reword without updating the cross-SDK copy spec.
 package constants
 
-import "fmt"
-
 // Injected parameter names and wire keys.
 const (
-	ParamSessionID     = "session_id"
-	ParamAgentID       = "agent_id"
-	ParamContext       = "context"
-	MCPInstructionsKey = "_mcp_instructions"
+	ParamSessionID = "session_id"
+	ParamAgentID   = "agent_id"
+	ParamContext   = "context"
 
-	// MirrorInstructionsKey is the member of the _mcp_instructions object that
-	// carries the agent-facing instruction text. Its siblings are named by
-	// ParamSessionID and ParamAgentID, so the mirror's shape and the injected
-	// parameter names cannot drift apart.
-	MirrorInstructionsKey = "instructions"
+	// MCPSessionKey is the structuredContent member carrying the handle
+	// mirror, and the property declared on extended output schemas. Its
+	// members are named by ParamSessionID, ParamAgentID, and the status enum
+	// owned by the inject package.
+	MCPSessionKey = "mcp_session"
 
 	MetaClientInfoKey      = "io.modelcontextprotocol/clientInfo"
 	MetaProtocolVersionKey = "io.modelcontextprotocol/protocolVersion"
@@ -43,52 +40,57 @@ const (
 	PrefixAgent   = "agt"
 )
 
-const SessionIDParamDescription = "REQUIRED on every call after your first. This MCP server associates all of your tool calls for a given task using session_id; a call that arrives without it cannot be associated with your earlier work and is treated as the start of an unrelated task, disconnected from the original goal. Omit it on your first call only — the server will issue one in the _mcp_instructions field of the result (or a trailing [MCP INSTRUCTIONS] text block) — then echo that exact value on every later call. Never invent a value, and do not issue parallel tool calls until the server has issued your session_id. One session_id covers the whole goal from start to finish: when you spawn subagents you MUST give them this same session_id, or their work is severed from yours. Without session_id, this server does not function as intended."
+const SessionIDParamDescription = "Session continuity handle, one of two values: the ses_ ID issued for the task underway, or start. This server cannot link your calls between requests on its own, so session continuity travels in this parameter instead. If you were handed a session_id for this task — for example by the agent that spawned you — send that exact value from your first call. Otherwise send start on your first call; the server will issue an opaque correlation ID in the mcp_session field of the result, or in a text block at the start of the result beginning [session_id issued. Then send that exact ses_ value on every later call and hand it to any subagents working the same task. start always begins a new, unrelated task — never send it mid-task. If you send a value this server does not recognize, the result reports it: mcp_session.status of unrecognized, or a text block beginning [session_id unrecognized; re-send the ID issued for this task, or start if none was issued yet. Never invent a ses_ value."
 
-const AgentIDParamDescription = "REQUIRED on every call, including your first. This MCP server distinguishes you from every other agent working this task using agent_id; a call that arrives without it cannot be attributed to you. Generate your own ID when you start work by joining three parts with '|': your model version, your harness name, and a short random suffix of 4-6 letters or digits chosen once. Example: opus-4.80-1m|claude-code|k3n9x. Send that same exact value on every call for your entire task; never change it mid-task. agent_id identifies you alone: a newly spawned subagent MUST generate its own instead of reusing its parent's. Without agent_id, this server does not function as intended."
+// SessionIDParamPattern is the JSON Schema pattern declared on the injected
+// session_id parameter. Its ses_ arm is exactly the shape both issuing paths
+// produce (KSUID: 27 base62 chars) — the same check handles.IsValidSessionID
+// applies — with the start sentinel as the only other member.
+const SessionIDParamPattern = "^(start|ses_[0-9A-Za-z]{27})$"
 
-const AgentIDParamDescriptionHookMode = "REQUIRED on every call, including your first. This MCP server distinguishes you from every other agent using agent_id; a call that arrives without it cannot be attributed to you. Generate your own ID when you start work by joining three parts with '|': your model version, your harness name, and a short random suffix of 4-6 letters or digits chosen once. Example: opus-4.80-1m|claude-code|k3n9x. Send that same exact value on every call for your entire task; never change it mid-task. agent_id identifies you alone: a newly spawned subagent MUST generate its own instead of reusing its parent's. Without agent_id, this server does not function as intended."
+// SessionStartSentinel is the session_id value that requests issuance: it
+// resolves exactly like an omitted session_id (matched case-insensitively;
+// the schema documents lowercase).
+const SessionStartSentinel = "start"
 
+// AgentIDParamDescription is the single agent_id description, used in both
+// prompted and hook mode.
+const AgentIDParamDescription = "Agent identity handle, required on every call including your first. This server cannot tell concurrent agents apart on its own; agent_id is how your calls are attributed to you. It is a self-chosen identifier in the spirit of a User-Agent string — join your model version, your harness name, and a short suffix of 4-6 letters or digits, with '|'. Example: opus-4.80-1m|claude-code|k3n9x. Choose the suffix once at the start of your task and send that same exact value on every call for the entire task; never change it mid-task, and a new task gets a fresh suffix. agent_id identifies exactly one agent and is never inherited: a subagent you spawn generates a new one rather than carrying yours, and if you were spawned by another agent, generate your own rather than reusing your parent's. A call without agent_id cannot be attributed to you."
+
+// Mint-back text block parts. The minted block is
+// MintBackHeaderIssued + "\n" + MintBackSessionLine(id) + "\n" + MintBackIssuedBody;
+// the unrecognized block is
+// MintBackHeaderUnrecognized + "\n" + MintBackUnrecognizedBody.
 const (
-	MintBackHeaderSession = "[MCP INSTRUCTIONS]: session_id issued."
-	MintBackHeaderInvalid = "[MCP INSTRUCTIONS]: session_id not recognized."
-	MintBackCloser        = "Without session_id, this server does not function as intended."
+	MintBackHeaderIssued       = "[session_id issued — see this tool's session_id parameter description]"
+	MintBackHeaderUnrecognized = "[session_id unrecognized — see this tool's session_id parameter description]"
 )
 
-// MintBackInvalidLine is the correction shown when the agent sends a
-// session_id this server never issued. Deliberately hands out NO replacement:
-// if a value arrived at all the agent was already issued a good one, and
-// giving it a second would split a conversation that was never split.
-const MintBackInvalidLine = "  The session_id you sent was not issued by this server. Re-send the exact session_id this server issued to you earlier in this conversation. Never invent a value."
+const MintBackIssuedBody = "This is the first-call issuance described in this tool's session_id parameter description."
 
-// MintBackSessionLine renders the middle line of the text mint-back block.
+// MintBackUnrecognizedBody names no session ID: no replacement is issued in
+// the same response. If a value arrived at all the agent was already issued a
+// good one, and handing it a second would split a conversation that was never
+// split; the recovery path is described in the body itself.
+const MintBackUnrecognizedBody = "The value sent was not issued by this server. Re-send the session_id issued earlier for this task; if none was issued yet, send start and one will be issued."
+
+// MintBackSessionLine renders the session_id line of the minted text block.
 func MintBackSessionLine(sessionID string) string {
-	return fmt.Sprintf("  session_id=%s — required on every subsequent tool call", sessionID)
+	return "session_id: " + sessionID
 }
 
-// MintBackConfirmed renders the structured-mirror instructions used when no
-// handle was minted this call. names is ["session_id"], ["agent_id"], or
-// ["session_id", "agent_id"] — in that order.
-func MintBackConfirmed(names []string) string {
-	joined := ""
-	for i, n := range names {
-		if i > 0 {
-			joined += " and "
-		}
-		joined += n
-	}
-	tail := "this exact value"
-	if len(names) > 1 {
-		tail = "these exact values"
-	}
-	return fmt.Sprintf("[MCP INSTRUCTIONS]: %s confirmed. Keep sending %s on every call.", joined, tail)
-}
+// mcp_session outputSchema copy: the field description per mode, and the
+// per-property descriptions. The status enum values live in the inject
+// package, which declares the enum alongside MCPSessionStatusDescription.
+const MCPSessionFieldDescription = "Session continuity and agent attribution state for this task, returned on completed responses that carry structured output. This server cannot link your calls between requests on its own, so session continuity travels here instead."
 
-const MCPInstructionsFieldDescription = "Your handles for this task, confirmed by this MCP server on every response, and the instructions for echoing them on later calls. Read and follow."
+const MCPSessionFieldDescriptionHookMode = "Agent attribution state for this task, returned on completed responses that carry structured output."
 
-const MCPInstructionsSessionIDDescription = "Echo this exact value as the session_id argument on every subsequent tool call."
+const MCPSessionSessionIDDescription = "Opaque correlation ID for this task, issued by this server. Use this as the session_id argument of every later call, and hand it to any subagents working the same task. Absent when status is unrecognized; no replacement is issued in that response — recovery is described under status."
 
-const MCPInstructionsAgentIDDescription = "Your agent_id as this server received it. Keep sending this exact value on every call; a subagent must generate its own."
+const MCPSessionAgentIDDescription = "Present only when you sent agent_id on this call. Your agent_id, echoed as received. Continue sending this exact value on every call; it is never inherited — a subagent you spawn generates its own."
+
+const MCPSessionStatusDescription = "issued: first call of a task; the session_id above was just created. active: the session_id you sent was accepted; keep sending it. unrecognized: the value sent was not issued by this server — re-send the one issued earlier for this task; if none was issued yet, send start to be issued a new one."
 
 // get_more_tools copy (unchanged from v1; pinned here as the single source).
 const (

--- a/internal/constants/constants_test.go
+++ b/internal/constants/constants_test.go
@@ -1,58 +1,49 @@
 package constants
 
-import (
-	"strings"
-	"testing"
-)
+import "testing"
 
 func TestAgentFacingCopyIsPinned(t *testing.T) {
 	// Byte-copies from agentcat-typescript-sdk src/modules/constants.ts
 	// (src/modules/tools.ts for the get_more_tools copy).
 	pins := map[string]struct{ got, want string }{
-		"session_id description":         {SessionIDParamDescription, "REQUIRED on every call after your first. This MCP server associates all of your tool calls for a given task using session_id; a call that arrives without it cannot be associated with your earlier work and is treated as the start of an unrelated task, disconnected from the original goal. Omit it on your first call only — the server will issue one in the _mcp_instructions field of the result (or a trailing [MCP INSTRUCTIONS] text block) — then echo that exact value on every later call. Never invent a value, and do not issue parallel tool calls until the server has issued your session_id. One session_id covers the whole goal from start to finish: when you spawn subagents you MUST give them this same session_id, or their work is severed from yours. Without session_id, this server does not function as intended."},
-		"agent_id description":           {AgentIDParamDescription, "REQUIRED on every call, including your first. This MCP server distinguishes you from every other agent working this task using agent_id; a call that arrives without it cannot be attributed to you. Generate your own ID when you start work by joining three parts with '|': your model version, your harness name, and a short random suffix of 4-6 letters or digits chosen once. Example: opus-4.80-1m|claude-code|k3n9x. Send that same exact value on every call for your entire task; never change it mid-task. agent_id identifies you alone: a newly spawned subagent MUST generate its own instead of reusing its parent's. Without agent_id, this server does not function as intended."},
-		"agent_id hook-mode description": {AgentIDParamDescriptionHookMode, "REQUIRED on every call, including your first. This MCP server distinguishes you from every other agent using agent_id; a call that arrives without it cannot be attributed to you. Generate your own ID when you start work by joining three parts with '|': your model version, your harness name, and a short random suffix of 4-6 letters or digits chosen once. Example: opus-4.80-1m|claude-code|k3n9x. Send that same exact value on every call for your entire task; never change it mid-task. agent_id identifies you alone: a newly spawned subagent MUST generate its own instead of reusing its parent's. Without agent_id, this server does not function as intended."},
-		"mint-back header":               {MintBackHeaderSession, "[MCP INSTRUCTIONS]: session_id issued."},
-		"mint-back invalid header":       {MintBackHeaderInvalid, "[MCP INSTRUCTIONS]: session_id not recognized."},
-		"mint-back invalid line":         {MintBackInvalidLine, "  The session_id you sent was not issued by this server. Re-send the exact session_id this server issued to you earlier in this conversation. Never invent a value."},
-		"mint-back closer":               {MintBackCloser, "Without session_id, this server does not function as intended."},
-		"mint-back line":                 {MintBackSessionLine("ses_ABC"), "  session_id=ses_ABC — required on every subsequent tool call"},
-		"confirmed single":               {MintBackConfirmed([]string{"session_id"}), "[MCP INSTRUCTIONS]: session_id confirmed. Keep sending this exact value on every call."},
-		"confirmed agent":                {MintBackConfirmed([]string{"agent_id"}), "[MCP INSTRUCTIONS]: agent_id confirmed. Keep sending this exact value on every call."},
-		"confirmed both":                 {MintBackConfirmed([]string{"session_id", "agent_id"}), "[MCP INSTRUCTIONS]: session_id and agent_id confirmed. Keep sending these exact values on every call."},
-		"field description":              {MCPInstructionsFieldDescription, "Your handles for this task, confirmed by this MCP server on every response, and the instructions for echoing them on later calls. Read and follow."},
-		"session_id sub-property":        {MCPInstructionsSessionIDDescription, "Echo this exact value as the session_id argument on every subsequent tool call."},
-		"agent_id sub-property":          {MCPInstructionsAgentIDDescription, "Your agent_id as this server received it. Keep sending this exact value on every call; a subagent must generate its own."},
-		"param session_id":               {ParamSessionID, "session_id"},
-		"param agent_id":                 {ParamAgentID, "agent_id"},
-		"param context":                  {ParamContext, "context"},
-		"mcp instructions key":           {MCPInstructionsKey, "_mcp_instructions"},
-		"mirror instructions key":        {MirrorInstructionsKey, "instructions"},
-		"tag session source":             {TagSessionSource, "agentcat_session_id_source"},
-		"tag agent id":                   {TagAgentID, "agentcat_agent_id"},
-		"tag agent source":               {TagAgentSource, "agentcat_agent_id_source"},
-		"tag protocol version":           {TagProtocolVersion, "agentcat_protocol_version"},
-		"tag mrtr":                       {TagMRTR, "agentcat_mrtr"},
-		"mrtr input required":            {MRTRInputRequired, "input_required"},
-		"mrtr continuation":              {MRTRContinuation, "continuation"},
-		"prefix session":                 {PrefixSession, "ses"},
-		"prefix event":                   {PrefixEvent, "evt"},
-		"prefix agent":                   {PrefixAgent, "agt"},
-		"meta client info":               {MetaClientInfoKey, "io.modelcontextprotocol/clientInfo"},
-		"meta protocol version":          {MetaProtocolVersionKey, "io.modelcontextprotocol/protocolVersion"},
-		"get_more_tools name":            {GetMoreToolsName, "get_more_tools"},
-		"get_more_tools description":     {GetMoreToolsDescription, "Check for additional tools whenever your task might benefit from specialized capabilities - even if existing tools could work as a fallback."},
-		"get_more_tools context":         {GetMoreToolsContextDescription, "A description of your goal and what kind of tool would help accomplish it."},
-		"get_more_tools response":        {GetMoreToolsResponseText, "Unfortunately, we have shown you the full tool list. We have noted your feedback and will work to improve the tool list in the future."},
+		"session_id description":        {SessionIDParamDescription, "Session continuity handle, one of two values: the ses_ ID issued for the task underway, or start. This server cannot link your calls between requests on its own, so session continuity travels in this parameter instead. If you were handed a session_id for this task — for example by the agent that spawned you — send that exact value from your first call. Otherwise send start on your first call; the server will issue an opaque correlation ID in the mcp_session field of the result, or in a text block at the start of the result beginning [session_id issued. Then send that exact ses_ value on every later call and hand it to any subagents working the same task. start always begins a new, unrelated task — never send it mid-task. If you send a value this server does not recognize, the result reports it: mcp_session.status of unrecognized, or a text block beginning [session_id unrecognized; re-send the ID issued for this task, or start if none was issued yet. Never invent a ses_ value."},
+		"session_id pattern":            {SessionIDParamPattern, "^(start|ses_[0-9A-Za-z]{27})$"},
+		"session start sentinel":        {SessionStartSentinel, "start"},
+		"agent_id description":          {AgentIDParamDescription, "Agent identity handle, required on every call including your first. This server cannot tell concurrent agents apart on its own; agent_id is how your calls are attributed to you. It is a self-chosen identifier in the spirit of a User-Agent string — join your model version, your harness name, and a short suffix of 4-6 letters or digits, with '|'. Example: opus-4.80-1m|claude-code|k3n9x. Choose the suffix once at the start of your task and send that same exact value on every call for the entire task; never change it mid-task, and a new task gets a fresh suffix. agent_id identifies exactly one agent and is never inherited: a subagent you spawn generates a new one rather than carrying yours, and if you were spawned by another agent, generate your own rather than reusing your parent's. A call without agent_id cannot be attributed to you."},
+		"mint-back issued header":       {MintBackHeaderIssued, "[session_id issued — see this tool's session_id parameter description]"},
+		"mint-back issued body":         {MintBackIssuedBody, "This is the first-call issuance described in this tool's session_id parameter description."},
+		"mint-back unrecognized header": {MintBackHeaderUnrecognized, "[session_id unrecognized — see this tool's session_id parameter description]"},
+		"mint-back unrecognized body":   {MintBackUnrecognizedBody, "The value sent was not issued by this server. Re-send the session_id issued earlier for this task; if none was issued yet, send start and one will be issued."},
+		"mint-back session line":        {MintBackSessionLine("ses_2cOHEO0LYGADMzRvWTXXVbbgxgm"), "session_id: ses_2cOHEO0LYGADMzRvWTXXVbbgxgm"},
+		"field description":             {MCPSessionFieldDescription, "Session continuity and agent attribution state for this task, returned on completed responses that carry structured output. This server cannot link your calls between requests on its own, so session continuity travels here instead."},
+		"field description hook mode":   {MCPSessionFieldDescriptionHookMode, "Agent attribution state for this task, returned on completed responses that carry structured output."},
+		"session_id sub-property":       {MCPSessionSessionIDDescription, "Opaque correlation ID for this task, issued by this server. Use this as the session_id argument of every later call, and hand it to any subagents working the same task. Absent when status is unrecognized; no replacement is issued in that response — recovery is described under status."},
+		"agent_id sub-property":         {MCPSessionAgentIDDescription, "Present only when you sent agent_id on this call. Your agent_id, echoed as received. Continue sending this exact value on every call; it is never inherited — a subagent you spawn generates its own."},
+		"status sub-property":           {MCPSessionStatusDescription, "issued: first call of a task; the session_id above was just created. active: the session_id you sent was accepted; keep sending it. unrecognized: the value sent was not issued by this server — re-send the one issued earlier for this task; if none was issued yet, send start to be issued a new one."},
+		"param session_id":              {ParamSessionID, "session_id"},
+		"param agent_id":                {ParamAgentID, "agent_id"},
+		"param context":                 {ParamContext, "context"},
+		"mcp session key":               {MCPSessionKey, "mcp_session"},
+		"tag session source":            {TagSessionSource, "agentcat_session_id_source"},
+		"tag agent id":                  {TagAgentID, "agentcat_agent_id"},
+		"tag agent source":              {TagAgentSource, "agentcat_agent_id_source"},
+		"tag protocol version":          {TagProtocolVersion, "agentcat_protocol_version"},
+		"tag mrtr":                      {TagMRTR, "agentcat_mrtr"},
+		"mrtr input required":           {MRTRInputRequired, "input_required"},
+		"mrtr continuation":             {MRTRContinuation, "continuation"},
+		"prefix session":                {PrefixSession, "ses"},
+		"prefix event":                  {PrefixEvent, "evt"},
+		"prefix agent":                  {PrefixAgent, "agt"},
+		"meta client info":              {MetaClientInfoKey, "io.modelcontextprotocol/clientInfo"},
+		"meta protocol version":         {MetaProtocolVersionKey, "io.modelcontextprotocol/protocolVersion"},
+		"get_more_tools name":           {GetMoreToolsName, "get_more_tools"},
+		"get_more_tools description":    {GetMoreToolsDescription, "Check for additional tools whenever your task might benefit from specialized capabilities - even if existing tools could work as a fallback."},
+		"get_more_tools context":        {GetMoreToolsContextDescription, "A description of your goal and what kind of tool would help accomplish it."},
+		"get_more_tools response":       {GetMoreToolsResponseText, "Unfortunately, we have shown you the full tool list. We have noted your feedback and will work to improve the tool list in the future."},
 	}
 	for name, p := range pins {
 		if p.got != p.want {
 			t.Errorf("%s drifted:\n got:  %q\n want: %q", name, p.got, p.want)
 		}
-	}
-	// The hook-mode variant differs from the default ONLY by dropping the
-	// task framing from the first sentence.
-	if got := strings.Replace(AgentIDParamDescription, "working this task ", "", 1); got != AgentIDParamDescriptionHookMode {
-		t.Error("hook-mode agent_id description must equal the default with the task framing removed")
 	}
 }

--- a/internal/handles/handles.go
+++ b/internal/handles/handles.go
@@ -140,6 +140,12 @@ func ResolveSessionHandle(args map[string]any, hook func() (string, error), proj
 		// stray whitespace still means the ID it was given, and the
 		// TypeScript SDK trims here too.
 		supplied := strings.TrimSpace(raw)
+		if strings.EqualFold(supplied, constants.SessionStartSentinel) {
+			// The start sentinel requests issuance and resolves exactly like an
+			// omitted session_id. EqualFold as grace for clients that do not
+			// enforce the schema pattern; the pattern documents lowercase.
+			return SessionResolution{SessionID: MintSessionID(), Source: SessionSourceMinted}
+		}
 		if IsValidSessionID(supplied) {
 			return SessionResolution{SessionID: supplied, Source: SessionSourceSupplied}
 		}
@@ -190,8 +196,9 @@ func ClampAgentID(v string) string {
 	return v
 }
 
-// BuildMintBackText renders the trailing [MCP INSTRUCTIONS] text block for one
-// call, or "" when there is nothing to say.
+// BuildMintBackText renders the leading text block for one call, or "" when
+// there is nothing to say. The block goes at the START of the result content:
+// IDs at the end of long responses can be truncated away by clients.
 //
 // Taking the whole resolution rather than an ID is deliberate: this is the one
 // place that decides whether a call announces anything at all. Both adapters
@@ -209,13 +216,12 @@ func BuildMintBackText(res SessionResolution) string {
 	}
 	switch res.Source {
 	case SessionSourceMinted:
-		return constants.MintBackHeaderSession + "\n" +
+		return constants.MintBackHeaderIssued + "\n" +
 			constants.MintBackSessionLine(res.SessionID) + "\n" +
-			constants.MintBackCloser
+			constants.MintBackIssuedBody
 	case SessionSourceInvalid:
-		return constants.MintBackHeaderInvalid + "\n" +
-			constants.MintBackInvalidLine + "\n" +
-			constants.MintBackCloser
+		return constants.MintBackHeaderUnrecognized + "\n" +
+			constants.MintBackUnrecognizedBody
 	default:
 		return ""
 	}

--- a/internal/handles/handles_test.go
+++ b/internal/handles/handles_test.go
@@ -116,6 +116,15 @@ func TestResolveSessionHandleDecisionTable(t *testing.T) {
 		wantSource SessionSource
 	}{
 		{"absent, ours: mint", map[string]any{}, nil, true, minted, SessionSourceMinted},
+		// The start sentinel resolves exactly like absent: mint. Matched
+		// case-insensitively and after trimming — grace for clients that do
+		// not enforce the schema pattern (which documents lowercase).
+		{"start sentinel, ours: mint", map[string]any{"session_id": "start"}, nil, true, minted, SessionSourceMinted},
+		{"START case variant, ours: mint", map[string]any{"session_id": "START"}, nil, true, minted, SessionSourceMinted},
+		{"padded Start, ours: mint", map[string]any{"session_id": "  Start "}, nil, true, minted, SessionSourceMinted},
+		// The sentinel is only ours to interpret: on a customer-owned
+		// parameter the literal value belongs to the customer's tool.
+		{"start, not ours: sessionless", map[string]any{"session_id": "start"}, nil, false, "", SessionSourceForeign},
 		{"valid, ours: trust verbatim", map[string]any{"session_id": valid}, nil, true, valid, SessionSourceSupplied},
 		{"padded valid, ours: trust trimmed", map[string]any{"session_id": " " + valid + " "}, nil, true, valid, SessionSourceSupplied},
 		{"garbage, ours: sessionless", map[string]any{"session_id": "nope"}, nil, true, "", SessionSourceInvalid},
@@ -189,12 +198,11 @@ func TestClampAgentID(t *testing.T) {
 
 func TestBuildMintBackText(t *testing.T) {
 	id := sid("A")
-	issued := "[MCP INSTRUCTIONS]: session_id issued.\n  session_id=" + id +
-		" — required on every subsequent tool call\n" +
-		"Without session_id, this server does not function as intended."
-	corrected := "[MCP INSTRUCTIONS]: session_id not recognized.\n" +
-		"  The session_id you sent was not issued by this server. Re-send the exact session_id this server issued to you earlier in this conversation. Never invent a value.\n" +
-		"Without session_id, this server does not function as intended."
+	issued := "[session_id issued — see this tool's session_id parameter description]\n" +
+		"session_id: " + id + "\n" +
+		"This is the first-call issuance described in this tool's session_id parameter description."
+	corrected := "[session_id unrecognized — see this tool's session_id parameter description]\n" +
+		"The value sent was not issued by this server. Re-send the session_id issued earlier for this task; if none was issued yet, send start and one will be issued."
 
 	for _, c := range []struct {
 		name string

--- a/internal/inject/inject.go
+++ b/internal/inject/inject.go
@@ -159,18 +159,65 @@ func stringParamSchema(description string) json.RawMessage {
 	return b
 }
 
-// instructionsPropertySchema is the optional _mcp_instructions property
-// declared on plain-object output schemas.
-func instructionsPropertySchema() json.RawMessage {
-	b, _ := json.Marshal(map[string]any{
-		"type":        "object",
-		"description": constants.MCPInstructionsFieldDescription,
-		"properties": map[string]any{
-			constants.ParamSessionID:        map[string]string{"type": "string", "description": constants.MCPInstructionsSessionIDDescription},
-			constants.ParamAgentID:          map[string]string{"type": "string", "description": constants.MCPInstructionsAgentIDDescription},
-			constants.MirrorInstructionsKey: map[string]string{"type": "string"},
-		},
+// sessionIDParamSchema is stringParamSchema plus the value pattern: the two
+// values the parameter accepts (start, or an issued ses_ ID) are
+// machine-checkable, so schema-enforcing clients reject invented or mangled
+// IDs before the call is ever sent.
+func sessionIDParamSchema() json.RawMessage {
+	b, _ := json.Marshal(map[string]string{
+		"type":        "string",
+		"description": constants.SessionIDParamDescription,
+		"pattern":     constants.SessionIDParamPattern,
 	})
+	return b
+}
+
+// Wire members and status enum values of the mcp_session mirror. The enum is
+// declared on the outputSchema fragment alongside MCPSessionStatusDescription.
+const (
+	mirrorStatusKey    = "status"
+	statusIssued       = "issued"
+	statusActive       = "active"
+	statusUnrecognized = "unrecognized"
+)
+
+// mcpSessionPropertySchema is the optional mcp_session property declared on
+// plain-object output schemas. Its description and its sub-properties are
+// mode-conditional, exactly mirroring what BuildMirror can put on the wire:
+// session_id and status exist only in prompted mode, agent_id only when agent
+// tracking is on. Property order: session_id, agent_id, status.
+func mcpSessionPropertySchema(cfg Config) json.RawMessage {
+	props := NewSchemaObject()
+	if !cfg.HookMode {
+		b, _ := json.Marshal(map[string]string{"type": "string", "description": constants.MCPSessionSessionIDDescription})
+		props.Set(constants.ParamSessionID, b)
+	}
+	if cfg.AgentTracking {
+		b, _ := json.Marshal(map[string]string{"type": "string", "description": constants.MCPSessionAgentIDDescription})
+		props.Set(constants.ParamAgentID, b)
+	}
+	if !cfg.HookMode {
+		b, _ := json.Marshal(map[string]any{
+			"type":        "string",
+			"enum":        []any{statusIssued, statusActive, statusUnrecognized},
+			"description": constants.MCPSessionStatusDescription,
+		})
+		props.Set(mirrorStatusKey, b)
+	}
+
+	description := constants.MCPSessionFieldDescription
+	if cfg.HookMode {
+		description = constants.MCPSessionFieldDescriptionHookMode
+	}
+
+	field := NewSchemaObject()
+	typeRaw, _ := json.Marshal("object")
+	field.Set("type", typeRaw)
+	descRaw, _ := json.Marshal(description)
+	field.Set("description", descRaw)
+	propsRaw, _ := json.Marshal(props)
+	field.Set("properties", propsRaw)
+	b, _ := json.Marshal(field)
 	return b
 }
 
@@ -236,10 +283,11 @@ func Build(cfg Config, tools []NormalizedTool) ([]NormalizedTool, *Registries) {
 				}
 
 				if cfg.InjectHandles && !cfg.HookMode {
-					want := stringParamSchema(constants.SessionIDParamDescription)
+					want := sessionIDParamSchema()
 					if claimProperty(props, constants.ParamSessionID, want) {
 						props.Set(constants.ParamSessionID, want)
 						injected = append(injected, constants.ParamSessionID)
+						required = appendUnique(required, constants.ParamSessionID)
 					} else {
 						// Recorded, not logged: the call path reports this
 						// once per tool with remediation. Escalated above a
@@ -248,11 +296,7 @@ func Build(cfg Config, tools []NormalizedTool) ([]NormalizedTool, *Registries) {
 					}
 				}
 				if cfg.InjectHandles && cfg.AgentTracking {
-					desc := constants.AgentIDParamDescription
-					if cfg.HookMode {
-						desc = constants.AgentIDParamDescriptionHookMode
-					}
-					want := stringParamSchema(desc)
+					want := stringParamSchema(constants.AgentIDParamDescription)
 					if claimProperty(props, constants.ParamAgentID, want) {
 						props.Set(constants.ParamAgentID, want)
 						injected = append(injected, constants.ParamAgentID)
@@ -290,10 +334,15 @@ func Build(cfg Config, tools []NormalizedTool) ([]NormalizedTool, *Registries) {
 			}
 		}
 
-		if cfg.InjectHandles {
+		// Output declaration only when at least one handle is injectable. In
+		// hook mode with agent tracking off the mcp_session fragment would
+		// declare no properties and BuildMirror can never produce a payload,
+		// so the field is not declared at all — matching the TypeScript and
+		// Python SDKs, which skip the handle pass entirely there.
+		if cfg.InjectHandles && (!cfg.HookMode || cfg.AgentTracking) {
 			if t.OutputSchemaOpaque {
 				logger.Warnf("inject: tool %q has an unreadable output schema; advertising it untouched and leaving mint-back content-only", t.Name)
-			} else if outSchema, did := injectOutput(t.Name, t.OutputSchema); did {
+			} else if outSchema, did := injectOutput(cfg, t.Name, t.OutputSchema); did {
 				result.OutputSchema = outSchema
 				reg.OutputInjected[t.Name] = true
 			}
@@ -380,12 +429,11 @@ func parsePropsAndRequired(toolName string, in *SchemaObject) (*SchemaObject, []
 	return props, required, true
 }
 
-// injectOutput declares the optional _mcp_instructions property on a
-// plain-object output schema. Returns (schema, false) untouched for absent,
-// composed, non-object, or customer-owned-key schemas. Output
-// additionalProperties is never modified: the declared property is what keeps
-// validators happy.
-func injectOutput(toolName string, out *SchemaObject) (*SchemaObject, bool) {
+// injectOutput declares the optional mcp_session property on a plain-object
+// output schema. Returns (schema, false) untouched for absent, composed,
+// non-object, or customer-owned-key schemas. Output additionalProperties is
+// never modified: the declared property is what keeps validators happy.
+func injectOutput(cfg Config, toolName string, out *SchemaObject) (*SchemaObject, bool) {
 	if out == nil {
 		return nil, false
 	}
@@ -410,12 +458,12 @@ func injectOutput(toolName string, out *SchemaObject) (*SchemaObject, bool) {
 		}
 		props = parsed
 	}
-	want := instructionsPropertySchema()
-	if !claimProperty(props, constants.MCPInstructionsKey, want) {
+	want := mcpSessionPropertySchema(cfg)
+	if !claimProperty(props, constants.MCPSessionKey, want) {
 		// Customer data — it wins; skip.
 		return out, false
 	}
-	props.Set(constants.MCPInstructionsKey, want)
+	props.Set(constants.MCPSessionKey, want)
 	propsRaw, err := json.Marshal(props)
 	if err != nil {
 		return out, false
@@ -478,47 +526,40 @@ type MirrorInput struct {
 	AgentID    string // supplied agent_id verbatim; "" when absent
 }
 
-// BuildMirror assembles the _mcp_instructions value mirrored into
-// structuredContent on every response. Returns nil when there is nothing
-// the agent could echo.
+// BuildMirror assembles the mcp_session value mirrored into structuredContent
+// on every response: {session_id?, agent_id?, status?}. Returns nil when the
+// payload would be empty.
 //
-// A session is echoable only when it is one this SDK issued and the agent has
-// a parameter to send it back on. That rules out hook mode (no parameter
-// exists) and invalid (the value was rejected, so echoing it would confirm an
-// ID this server never issued — the exact loop validation exists to break).
-// A foreign call mirrors nothing at all: the parameter belongs to the
-// customer's tool, so AgentCat has no standing to speak about it.
+// session_id and status exist only in prompted mode. A session is echoable
+// only when it is one this SDK issued and the agent has a parameter to send it
+// back on; status pre-announces which of the schema's declared states this
+// response is in (issued / active / unrecognized). Hook mode carries agent_id
+// only: no parameter exists for the agent to echo, so there is no session
+// state to name. A foreign call (the session_id parameter belongs to the
+// customer's tool) is the same — the parameter is not ours to speak about, so
+// only agent_id is mirrored.
 func BuildMirror(in MirrorInput) map[string]any {
 	res := in.Resolution
-	if res.Source == handles.SessionSourceForeign {
-		return nil
-	}
-
-	sessionEchoable := !res.HookMode &&
-		res.Source != handles.SessionSourceInvalid &&
-		res.SessionID != ""
-
 	m := map[string]any{}
-	var names []string
-	if sessionEchoable {
-		m[constants.ParamSessionID] = res.SessionID
-		names = append(names, constants.ParamSessionID)
+	if !res.HookMode && res.Source != handles.SessionSourceForeign {
+		switch res.Source {
+		case handles.SessionSourceMinted:
+			m[constants.ParamSessionID] = res.SessionID
+			m[mirrorStatusKey] = statusIssued
+		case handles.SessionSourceSupplied:
+			m[constants.ParamSessionID] = res.SessionID
+			m[mirrorStatusKey] = statusActive
+		case handles.SessionSourceInvalid:
+			// No session_id key: echoing back a value this server rejected
+			// would confirm an ID it never issued.
+			m[mirrorStatusKey] = statusUnrecognized
+		}
 	}
 	if in.AgentID != "" {
 		m[constants.ParamAgentID] = in.AgentID
-		names = append(names, constants.ParamAgentID)
 	}
-
-	text := handles.BuildMintBackText(res)
-	if len(m) == 0 && text == "" {
+	if len(m) == 0 {
 		return nil
-	}
-	if text != "" {
-		// minted (announce) or invalid (correct). The invalid shape carries
-		// instructions and any agent_id, but no session_id key.
-		m[constants.MirrorInstructionsKey] = text
-	} else {
-		m[constants.MirrorInstructionsKey] = constants.MintBackConfirmed(names)
 	}
 	return m
 }

--- a/internal/inject/inject_test.go
+++ b/internal/inject/inject_test.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"go.agentcat.com/sdk/v2/internal/constants"
 )
 
 func mustParse(t *testing.T, s string) *SchemaObject {
@@ -44,11 +46,11 @@ func TestBuildOrderingAndRegistry(t *testing.T) {
 	if got := props.Keys(); strings.Join(got, ",") != strings.Join(wantOrder, ",") {
 		t.Errorf("property order = %v, want %v", got, wantOrder)
 	}
-	// session_id never required; agent_id and context appended to required.
+	// All three injected params append to required, customer entries first.
 	var required []string
 	rawReq, _ := out[0].InputSchema.Get("required")
 	_ = json.Unmarshal(rawReq, &required)
-	if strings.Join(required, ",") != "zebra,agent_id,context" {
+	if strings.Join(required, ",") != "zebra,session_id,agent_id,context" {
 		t.Errorf("required = %v", required)
 	}
 	if got := reg.InjectedParams["todo"]; strings.Join(got, ",") != "session_id,agent_id,context" {
@@ -73,13 +75,42 @@ func TestBuildHookModeSkipsSessionID(t *testing.T) {
 	if props.Has("session_id") {
 		t.Error("hook mode must not inject session_id")
 	}
-	// Hook-mode agent_id description differs from default mode.
+	// One agent_id description in both modes.
 	raw, _ := props.Get("agent_id")
-	if !strings.Contains(string(raw), "distinguishes you from every other agent using agent_id") {
-		t.Errorf("agent_id must use hook-mode description, got %s", raw)
+	if !strings.Contains(string(raw), "cannot tell concurrent agents apart on its own") {
+		t.Errorf("agent_id must use the single description in hook mode, got %s", raw)
 	}
 	if got := reg.InjectedParams["t"]; strings.Join(got, ",") != "agent_id,context" {
 		t.Errorf("registry = %v", got)
+	}
+	// agent_id stays required wherever it is injected, hook mode included.
+	var required []string
+	rawReq, _ := out[0].InputSchema.Get("required")
+	_ = json.Unmarshal(rawReq, &required)
+	if strings.Join(required, ",") != "agent_id,context" {
+		t.Errorf("required = %v", required)
+	}
+}
+
+// TestSessionIDParamCarriesPattern pins the machine-checkable half of the
+// session_id contract: the injected property declares the exact value pattern
+// (start, or an issued ses_ ID) so schema-enforcing clients validate before
+// sending. agent_id and context stay pattern-free.
+func TestSessionIDParamCarriesPattern(t *testing.T) {
+	out, _ := Build(defaultCfg(), []NormalizedTool{{
+		Name:        "t",
+		InputSchema: mustParse(t, `{"type":"object","properties":{}}`),
+	}})
+	props := propertiesOf(t, out[0].InputSchema)
+	raw, _ := props.Get("session_id")
+	if !strings.Contains(string(raw), constants.SessionIDParamPattern) {
+		t.Errorf("session_id must declare the value pattern, got %s", raw)
+	}
+	for _, name := range []string{"context"} {
+		raw, _ := props.Get(name)
+		if strings.Contains(string(raw), "pattern") {
+			t.Errorf("%s must not declare a pattern, got %s", name, raw)
+		}
 	}
 }
 
@@ -120,6 +151,13 @@ func TestBuildCollisionSkipsThatParamOnly(t *testing.T) {
 	if got := reg.InjectedParams["t"]; strings.Join(got, ",") != "context" {
 		t.Errorf("only context should be recorded, got %v", got)
 	}
+	// A customer-owned session_id is never forced required by this SDK.
+	var required []string
+	rawReq, _ := out[0].InputSchema.Get("required")
+	_ = json.Unmarshal(rawReq, &required)
+	if slices.Contains(required, "session_id") {
+		t.Errorf("customer-owned session_id must not join required, got %v", required)
+	}
 }
 
 func TestBuildOutputSchemaInjection(t *testing.T) {
@@ -130,17 +168,26 @@ func TestBuildOutputSchemaInjection(t *testing.T) {
 		{Name: "composed", InputSchema: mustParse(t, `{"type":"object","properties":{}}`),
 			OutputSchema: mustParse(t, `{"oneOf":[{"type":"object"}]}`)},
 		{Name: "customerkey", InputSchema: mustParse(t, `{"type":"object","properties":{}}`),
-			OutputSchema: mustParse(t, `{"type":"object","properties":{"_mcp_instructions":{"type":"string"}}}`)},
+			OutputSchema: mustParse(t, `{"type":"object","properties":{"mcp_session":{"type":"string"}}}`)},
 	})
 	if !reg.OutputInjected["declared"] {
 		t.Error("declared plain-object outputSchema must be extended")
 	}
 	oProps := propertiesOf(t, out[0].OutputSchema)
-	raw, _ := oProps.Get("_mcp_instructions")
-	for _, want := range []string{"Read and follow.", "session_id argument", "a subagent must generate its own"} {
+	raw, _ := oProps.Get("mcp_session")
+	for _, want := range []string{
+		"Session continuity and agent attribution state",
+		"Use this as the session_id argument",
+		`"enum":["issued","active","unrecognized"]`,
+		"keep sending it",
+	} {
 		if !strings.Contains(string(raw), want) {
-			t.Errorf("_mcp_instructions schema missing %q: %s", want, raw)
+			t.Errorf("mcp_session schema missing %q: %s", want, raw)
 		}
+	}
+	// defaultCfg has agent tracking off: no agent_id sub-property.
+	if strings.Contains(string(raw), `"agent_id"`) {
+		t.Errorf("agent_id must not be declared without agent tracking: %s", raw)
 	}
 	// Output additionalProperties:false must be preserved (declared property suffices).
 	if !out[0].OutputSchema.Has("additionalProperties") {
@@ -151,11 +198,83 @@ func TestBuildOutputSchemaInjection(t *testing.T) {
 			t.Errorf("%s must not be in the output registry", name)
 		}
 	}
-	// Customer's own _mcp_instructions declaration wins, untouched.
+	// Customer's own mcp_session declaration wins, untouched.
 	cProps := propertiesOf(t, out[3].OutputSchema)
-	raw, _ = cProps.Get("_mcp_instructions")
+	raw, _ = cProps.Get("mcp_session")
 	if string(raw) != `{"type":"string"}` {
-		t.Errorf("customer _mcp_instructions changed: %s", raw)
+		t.Errorf("customer mcp_session changed: %s", raw)
+	}
+}
+
+// TestOutputSchemaPropertiesAreModeConditional pins the mcp_session fragment's
+// shape per mode: session_id and status exist only in prompted mode, agent_id
+// only when agent tracking is on, in the order session_id, agent_id, status.
+func TestOutputSchemaPropertiesAreModeConditional(t *testing.T) {
+	tool := func() NormalizedTool {
+		return NormalizedTool{
+			Name:         "t",
+			InputSchema:  mustParse(t, `{"type":"object","properties":{}}`),
+			OutputSchema: mustParse(t, `{"type":"object","properties":{}}`),
+		}
+	}
+	field := func(cfg Config) *SchemaObject {
+		t.Helper()
+		out, reg := Build(cfg, []NormalizedTool{tool()})
+		if !reg.OutputInjected["t"] {
+			t.Fatal("output schema must be extended")
+		}
+		raw, ok := propertiesOf(t, out[0].OutputSchema).Get("mcp_session")
+		if !ok {
+			t.Fatal("mcp_session must be declared")
+		}
+		return mustParse(t, string(raw))
+	}
+
+	prompted := field(Config{InjectHandles: true, AgentTracking: true})
+	if desc, _ := prompted.Get("description"); !strings.Contains(string(desc), "session continuity travels here instead") {
+		t.Errorf("prompted mode must use the prompted field description, got %s", desc)
+	}
+	if got := propertiesOf(t, prompted).Keys(); strings.Join(got, ",") != "session_id,agent_id,status" {
+		t.Errorf("prompted+tracking properties = %v, want [session_id agent_id status]", got)
+	}
+
+	hook := field(Config{InjectHandles: true, HookMode: true, AgentTracking: true})
+	if desc, _ := hook.Get("description"); !strings.Contains(string(desc), "Agent attribution state for this task") {
+		t.Errorf("hook mode must use the hook-mode field description, got %s", desc)
+	}
+	if got := propertiesOf(t, hook).Keys(); strings.Join(got, ",") != "agent_id" {
+		t.Errorf("hook-mode properties = %v, want [agent_id]", got)
+	}
+
+	// Hook mode with agent tracking OFF: no sub-property would exist and
+	// BuildMirror can never produce a payload in that mode, so the field is
+	// not declared at all — the schema passes through untouched and the tool
+	// never enters the output-injection registry (parity with the TypeScript
+	// and Python SDKs, which skip the handle pass entirely there).
+	outD, regD := Build(Config{InjectHandles: true, HookMode: true}, []NormalizedTool{tool()})
+	if regD.OutputInjected["t"] {
+		t.Error("hook mode without agent tracking must not extend the output schema")
+	}
+	if got := marshalStr(t, outD[0].OutputSchema); got != `{"type":"object","properties":{}}` {
+		t.Errorf("hook mode without agent tracking must leave the output schema untouched, got %s", got)
+	}
+
+	statusRaw, ok := propertiesOf(t, prompted).Get("status")
+	if !ok {
+		t.Fatal("prompted mode must declare status")
+	}
+	var status struct {
+		Enum        []string `json:"enum"`
+		Description string   `json:"description"`
+	}
+	if err := json.Unmarshal(statusRaw, &status); err != nil {
+		t.Fatalf("status schema: %v", err)
+	}
+	if strings.Join(status.Enum, ",") != "issued,active,unrecognized" {
+		t.Errorf("status enum = %v", status.Enum)
+	}
+	if !strings.Contains(status.Description, "re-send the one issued earlier for this task") {
+		t.Errorf("status description drifted: %q", status.Description)
 	}
 }
 
@@ -235,7 +354,7 @@ func TestBuildIsIdempotent(t *testing.T) {
 	var required []string
 	rawReq, _ := twice[0].InputSchema.Get("required")
 	_ = json.Unmarshal(rawReq, &required)
-	if strings.Join(required, ",") != "q,agent_id,context" {
+	if strings.Join(required, ",") != "q,session_id,agent_id,context" {
 		t.Errorf("required must not accumulate duplicates, got %v", required)
 	}
 }

--- a/internal/inject/strip_test.go
+++ b/internal/inject/strip_test.go
@@ -59,8 +59,6 @@ func TestStripFallbackWithoutRegistry(t *testing.T) {
 func TestBuildHandleMirror(t *testing.T) {
 	id := sid("A")
 	const agent = "opus|cc|k3n9x"
-	issued := handles.BuildMintBackText(handles.SessionResolution{SessionID: id, Source: handles.SessionSourceMinted})
-	corrected := handles.BuildMintBackText(handles.SessionResolution{Source: handles.SessionSourceInvalid})
 
 	for _, c := range []struct {
 		name        string
@@ -68,52 +66,64 @@ func TestBuildHandleMirror(t *testing.T) {
 		wantNil     bool
 		wantSession string // "" = the session_id key must be ABSENT
 		wantAgent   string // "" = the agent_id key must be ABSENT
-		wantInstr   string
+		wantStatus  string // "" = the status key must be ABSENT
 	}{
 		{
 			name:        "minted: announce the handle",
 			in:          MirrorInput{Resolution: handles.SessionResolution{SessionID: id, Source: handles.SessionSourceMinted}},
-			wantSession: id, wantInstr: issued,
+			wantSession: id, wantStatus: "issued",
 		},
 		{
-			name:        "supplied: confirm it",
+			name:        "supplied: active",
 			in:          MirrorInput{Resolution: handles.SessionResolution{SessionID: id, Source: handles.SessionSourceSupplied}},
-			wantSession: id, wantInstr: "[MCP INSTRUCTIONS]: session_id confirmed. Keep sending this exact value on every call.",
+			wantSession: id, wantStatus: "active",
 		},
 		{
-			name:        "supplied with agent: confirm both",
+			name:        "supplied with agent: both handles",
 			in:          MirrorInput{Resolution: handles.SessionResolution{SessionID: id, Source: handles.SessionSourceSupplied}, AgentID: agent},
-			wantSession: id, wantAgent: agent,
-			wantInstr: "[MCP INSTRUCTIONS]: session_id and agent_id confirmed. Keep sending these exact values on every call.",
+			wantSession: id, wantAgent: agent, wantStatus: "active",
 		},
 		{
-			// The correction, and NO session_id key: echoing back a value we
-			// rejected would confirm an ID this server never issued.
-			name:      "invalid: correct, name no session",
-			in:        MirrorInput{Resolution: handles.SessionResolution{Source: handles.SessionSourceInvalid}},
-			wantInstr: corrected,
+			// NO session_id key: echoing back a value we rejected would
+			// confirm an ID this server never issued.
+			name:       "invalid: unrecognized, name no session",
+			in:         MirrorInput{Resolution: handles.SessionResolution{Source: handles.SessionSourceInvalid}},
+			wantStatus: "unrecognized",
 		},
 		{
-			name:      "invalid with agent: correct, keep the agent",
-			in:        MirrorInput{Resolution: handles.SessionResolution{Source: handles.SessionSourceInvalid}, AgentID: agent},
-			wantAgent: agent, wantInstr: corrected,
+			name:       "invalid with agent: unrecognized, keep the agent",
+			in:         MirrorInput{Resolution: handles.SessionResolution{Source: handles.SessionSourceInvalid}, AgentID: agent},
+			wantAgent:  agent,
+			wantStatus: "unrecognized",
 		},
 		{
-			// Not ours to speak about, even when an agent_id did arrive.
-			name:    "foreign: mirror nothing",
-			in:      MirrorInput{Resolution: handles.SessionResolution{Source: handles.SessionSourceForeign}, AgentID: agent},
+			// The session parameter is the customer's, so no session state is
+			// named — but the agent's own handle is still echoed.
+			name:      "foreign with agent: agent only",
+			in:        MirrorInput{Resolution: handles.SessionResolution{Source: handles.SessionSourceForeign}, AgentID: agent},
+			wantAgent: agent,
+		},
+		{
+			name:    "foreign alone: nothing to mirror",
+			in:      MirrorInput{Resolution: handles.SessionResolution{Source: handles.SessionSourceForeign}},
 			wantNil: true,
 		},
 		{
 			name:      "hook with agent: agent only",
 			in:        MirrorInput{Resolution: handles.SessionResolution{SessionID: id, Source: handles.SessionSourceHook, HookMode: true}, AgentID: agent},
 			wantAgent: agent,
-			wantInstr: "[MCP INSTRUCTIONS]: agent_id confirmed. Keep sending this exact value on every call.",
 		},
 		{
 			name:    "hook alone: nothing to mirror",
 			in:      MirrorInput{Resolution: handles.SessionResolution{SessionID: id, Source: handles.SessionSourceHook, HookMode: true}},
 			wantNil: true,
+		},
+		{
+			// The hook fallback mint is still hook mode: no parameter exists
+			// for the agent to echo, so no session state is named.
+			name:      "hook-mode mint with agent: agent only",
+			in:        MirrorInput{Resolution: handles.SessionResolution{SessionID: id, Source: handles.SessionSourceMinted, HookMode: true}, AgentID: agent},
+			wantAgent: agent,
 		},
 	} {
 		t.Run(c.name, func(t *testing.T) {
@@ -141,8 +151,17 @@ func TestBuildHandleMirror(t *testing.T) {
 			} else if got != c.wantAgent {
 				t.Errorf("agent_id = %v, want %q", got, c.wantAgent)
 			}
-			if got := m["instructions"]; got != c.wantInstr {
-				t.Errorf("instructions =\n %q\nwant\n %q", got, c.wantInstr)
+			if got, ok := m["status"]; c.wantStatus == "" {
+				if ok {
+					t.Errorf("status must be absent, got %v", got)
+				}
+			} else if got != c.wantStatus {
+				t.Errorf("status = %v, want %q", got, c.wantStatus)
+			}
+			for k := range m {
+				if k != "session_id" && k != "agent_id" && k != "status" {
+					t.Errorf("unexpected mirror member %q", k)
+				}
 			}
 		})
 	}

--- a/mcpcat.go
+++ b/mcpcat.go
@@ -238,8 +238,8 @@ func ResolveSessionHandle(args map[string]any, hook func() (string, error), proj
 // truncated to 200 bytes on a rune boundary.
 func ClampAgentID(v string) string { return handles.ClampAgentID(v) }
 
-// BuildMintBackText renders the trailing [MCP INSTRUCTIONS] content block for
-// one call, or "" when there is nothing to say. It is the single decision
+// BuildMintBackText renders the leading text content block for one call, or
+// "" when there is nothing to say. It is the single decision
 // point for whether a call announces anything: minted announces the new
 // handle, invalid corrects the agent without issuing a replacement, and hook,
 // foreign and supplied say nothing. Adapters must not re-derive it.

--- a/mcpgo/call_middleware.go
+++ b/mcpgo/call_middleware.go
@@ -298,28 +298,30 @@ func decorateResult(
 	cp := *res
 	cp.Content = append([]mcp.Content(nil), res.Content...)
 
-	// (a) Trailing text block: on the call that minted a new session, and on
+	// (a) Leading text block: on the call that minted a new session, and on
 	// one that sent a session_id this server never issued. BuildMintBackText
 	// owns that decision — hook mode, foreign and supplied all return "".
-	// Applied unconditionally otherwise: to error results (the retry after an
-	// error must carry the same session) and to tools that return no content
-	// at all (structured-only tools would otherwise never learn their session,
-	// and every call would mint a fresh one).
+	// Prepended as the FIRST content element: IDs at the end of long responses
+	// can be truncated away by clients. Applied unconditionally otherwise: to
+	// error results (the retry after an error must carry the same session) and
+	// to tools that return no content at all (structured-only tools would
+	// otherwise never learn their session, and every call would mint a fresh
+	// one).
 	if text := agentcat.BuildMintBackText(resolution); text != "" {
-		cp.Content = append(cp.Content, mcp.NewTextContent(text))
+		cp.Content = append([]mcp.Content{mcp.NewTextContent(text)}, cp.Content...)
 	}
 
 	// (b) Structured mirror: persistent handle state on every response, gated
 	// on the output-injection registry, plain-object structuredContent only,
-	// customer's own _mcp_instructions key wins.
+	// customer's own mcp_session key wins.
 	mirror := agentcat.BuildHandleMirror(agentcat.MirrorInput{
 		Resolution: resolution,
 		AgentID:    agentID,
 	})
 	if mirror != nil && agentcat.ShouldMirror(toolName, reg) {
 		if sc, ok := structuredContentAsMap(res); ok {
-			if _, customerOwns := sc[agentcat.MCPInstructionsKey]; !customerOwns {
-				sc[agentcat.MCPInstructionsKey] = mirror
+			if _, customerOwns := sc[agentcat.MCPSessionKey]; !customerOwns {
+				sc[agentcat.MCPSessionKey] = mirror
 				cp.StructuredContent = sc
 				// The preserved wire bytes would otherwise win at marshal time.
 				clearRawStructuredContent(&cp)
@@ -361,8 +363,9 @@ func undecorateResult(res *mcp.CallToolResult) *mcp.CallToolResult {
 }
 
 // withoutMintBackBlocks drops every content block that is provably a mint-back
-// block this SDK appended. Position is not assumed: an outer middleware may
-// have appended content of its own after ours.
+// block this SDK prepended. Position is not assumed even though decorateResult
+// writes the block first: an outer middleware may have added content of its
+// own around ours.
 func withoutMintBackBlocks(content []mcp.Content) ([]mcp.Content, bool) {
 	dropped := false
 	kept := make([]mcp.Content, 0, len(content))
@@ -427,15 +430,16 @@ func isHandleChar(c byte) bool {
 		(c >= 'A' && c <= 'Z')
 }
 
-// withoutHandleMirror drops the _mcp_instructions entry when its value is
-// provably the mirror this SDK builds. A customer's own value under that key
-// is left alone: decorateResult never overwrites one, so it cannot be ours.
+// withoutHandleMirror drops the mcp_session entry when its value is provably
+// the {session_id?, agent_id?, status?} mirror this SDK builds. A customer's
+// own value under that key is left alone: decorateResult never overwrites
+// one, so it cannot be ours.
 func withoutHandleMirror(res *mcp.CallToolResult) (map[string]any, bool) {
 	structured, ok := structuredContentAsMap(res)
 	if !ok {
 		return nil, false
 	}
-	mirror, ok := structured[agentcat.MCPInstructionsKey].(map[string]any)
+	mirror, ok := structured[agentcat.MCPSessionKey].(map[string]any)
 	if !ok {
 		return nil, false
 	}
@@ -443,9 +447,9 @@ func withoutHandleMirror(res *mcp.CallToolResult) (map[string]any, bool) {
 	sessionID, _ := mirror[agentcat.ParamSessionID].(string)
 	agentID, _ := mirror[agentcat.ParamAgentID].(string)
 	// Try every resolution this SDK could have mirrored. Enumerating
-	// resolutions rather than a minted true/false pair keeps this honest as
-	// sources are added: invalid and hook both produce a mirror with no
-	// session_id key, and neither is reachable by naming an ID.
+	// resolutions rather than reading the status member keeps this honest as
+	// sources are added: invalid produces a mirror with no session_id key, and
+	// hook and foreign produce one with agent_id alone.
 	for _, res := range []agentcat.SessionResolution{
 		{SessionID: sessionID, Source: agentcat.SessionSourceMinted},
 		{SessionID: sessionID, Source: agentcat.SessionSourceSupplied},
@@ -454,7 +458,7 @@ func withoutHandleMirror(res *mcp.CallToolResult) (map[string]any, bool) {
 	} {
 		rebuilt := agentcat.BuildHandleMirror(agentcat.MirrorInput{Resolution: res, AgentID: agentID})
 		if reflect.DeepEqual(rebuilt, mirror) {
-			delete(structured, agentcat.MCPInstructionsKey)
+			delete(structured, agentcat.MCPSessionKey)
 			return structured, true
 		}
 	}

--- a/mcpgo/concurrency_test.go
+++ b/mcpgo/concurrency_test.go
@@ -144,7 +144,7 @@ func TestParallelCallsDoNotCrossAttribute(t *testing.T) {
 func TestParallelCallsMintDistinctSessions(t *testing.T) {
 	call, mock := newConcurrencyClient(t, nil)
 
-	lastTexts := make([]string, parallelCalls)
+	firstTexts := make([]string, parallelCalls)
 
 	var wg sync.WaitGroup
 	for i := range parallelCalls {
@@ -162,12 +162,12 @@ func TestParallelCallsMintDistinctSessions(t *testing.T) {
 				t.Errorf("call %d returned no content", i)
 				return
 			}
-			tc, ok := res.Content[len(res.Content)-1].(mcp.TextContent)
+			tc, ok := res.Content[0].(mcp.TextContent)
 			if !ok {
-				t.Errorf("call %d: last content block is %T", i, res.Content[len(res.Content)-1])
+				t.Errorf("call %d: first content block is %T", i, res.Content[0])
 				return
 			}
-			lastTexts[i] = tc.Text
+			firstTexts[i] = tc.Text
 		}()
 	}
 	wg.Wait()
@@ -197,7 +197,7 @@ func TestParallelCallsMintDistinctSessions(t *testing.T) {
 		t.Errorf("expected %d distinct minted sessions, got %d", parallelCalls, len(minted))
 	}
 
-	for i, got := range lastTexts {
+	for i, got := range firstTexts {
 		session, ok := sessionByPayload[strconv.Itoa(i)]
 		if !ok {
 			t.Errorf("no event for call %d", i)

--- a/mcpgo/failure_hooks_test.go
+++ b/mcpgo/failure_hooks_test.go
@@ -334,8 +334,8 @@ func TestEvictedRecordPublishesUndecoratedResponse(t *testing.T) {
 		t.Fatalf("CallTool: %v", err)
 	}
 	// Precondition: the wire result really is decorated.
-	if !strings.Contains(lastText(t, res), "session_id issued") {
-		t.Fatalf("fixture must produce a decorated wire result: %q", lastText(t, res))
+	if !strings.Contains(firstText(t, res), "session_id issued") {
+		t.Fatalf("fixture must produce a decorated wire result: %q", firstText(t, res))
 	}
 
 	var evt *agentcat.Event
@@ -349,10 +349,10 @@ func TestEvictedRecordPublishesUndecoratedResponse(t *testing.T) {
 	}
 
 	response := fmt.Sprint(evt.Response)
-	if strings.Contains(response, "MCP INSTRUCTIONS") {
+	if strings.Contains(response, "[session_id") {
 		t.Errorf("mint-back leaked into the published event response: %s", response)
 	}
-	if strings.Contains(response, "_mcp_instructions") {
+	if strings.Contains(response, "mcp_session") {
 		t.Errorf("mirror leaked into the published event response: %s", response)
 	}
 	if !strings.Contains(response, "structured") {

--- a/mcpgo/go.mod
+++ b/mcpgo/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/mark3labs/mcp-go v0.57.0
-	go.agentcat.com/sdk/v2 v2.0.0
+	go.agentcat.com/sdk/v2 v2.1.0
 )
 
 require (

--- a/mcpgo/handles_test.go
+++ b/mcpgo/handles_test.go
@@ -23,16 +23,17 @@ func TestCallMintsSessionAndMintsBack(t *testing.T) {
 		"context": "adding my first todo",
 	})
 
-	// 1. The wire response carries the trailing mint-back text block…
-	if got := lastText(t, res); !strings.HasPrefix(got, "[MCP INSTRUCTIONS]: session_id issued.") {
-		t.Errorf("missing mint-back block, last content = %q", got)
+	// 1. The wire response carries the leading mint-back text block as its
+	// FIRST content element…
+	if got := firstText(t, res); !strings.HasPrefix(got, "[session_id issued") {
+		t.Errorf("missing mint-back block, first content = %q", got)
 	}
 	// …and the published event does NOT (wire-only discipline).
 	resp := fmt.Sprint(evt.Response)
-	if strings.Contains(resp, "MCP INSTRUCTIONS") {
+	if strings.Contains(resp, "[session_id") {
 		t.Errorf("mint-back leaked into the published event response: %s", resp)
 	}
-	if strings.Contains(resp, "_mcp_instructions") {
+	if strings.Contains(resp, "mcp_session") {
 		t.Errorf("mirror leaked into the published event response: %s", resp)
 	}
 
@@ -44,7 +45,7 @@ func TestCallMintsSessionAndMintsBack(t *testing.T) {
 	if evt.Tags == nil || (*evt.Tags)["agentcat_session_id_source"] != "minted" {
 		t.Errorf("session source tag missing or wrong: %v", evt.Tags)
 	}
-	if !strings.Contains(lastText(t, res), evt.GetSessionId()) {
+	if !strings.Contains(firstText(t, res), evt.GetSessionId()) {
 		t.Error("mint-back text does not name the event's session id")
 	}
 
@@ -64,6 +65,34 @@ func TestCallMintsSessionAndMintsBack(t *testing.T) {
 	_, evt2 := h.call("add_todo", map[string]any{"title": "again", "context": "x"})
 	if evt2.GetSessionId() == evt.GetSessionId() {
 		t.Error("two mint calls must mint distinct sessions (stateless per call)")
+	}
+}
+
+// TestStartSentinelMintsLikeOmission pins the start value's contract: it
+// resolves exactly like a first call that sent nothing — mint, issued block —
+// and the literal value is never adopted as a session.
+func TestStartSentinelMintsLikeOmission(t *testing.T) {
+	h := newSpyHarness(t, nil)
+
+	res, evt := h.call("add_todo", map[string]any{"title": "hi", "session_id": "start"})
+	if got := firstText(t, res); !strings.HasPrefix(got, "[session_id issued") {
+		t.Errorf("start must be issued a session, first content = %q", got)
+	}
+	if !strings.HasPrefix(evt.GetSessionId(), "ses_") {
+		t.Errorf("sessionId = %q, want a minted ses_ id", evt.GetSessionId())
+	}
+	if evt.Tags == nil || (*evt.Tags)["agentcat_session_id_source"] != "minted" {
+		t.Errorf("session source tag must be minted, got %v", evt.Tags)
+	}
+	// Case variants are graced (the schema pattern documents lowercase).
+	_, evt2 := h.call("add_todo", map[string]any{"title": "hi", "session_id": " START "})
+	if evt2.Tags == nil || (*evt2.Tags)["agentcat_session_id_source"] != "minted" {
+		t.Errorf("case-variant start must still mint, got %v", evt2.Tags)
+	}
+	// The raw record keeps the sentinel verbatim.
+	args, _ := evt.Parameters["arguments"].(map[string]any)
+	if args["session_id"] != "start" {
+		t.Errorf("raw arguments must record the sentinel, got %v", args)
 	}
 }
 
@@ -96,8 +125,8 @@ func TestErrorResultsStillGetMintBack(t *testing.T) {
 	if !res.IsError {
 		t.Fatal("fixture tool must return an IsError result")
 	}
-	if got := lastText(t, res); !strings.Contains(got, "session_id issued") {
-		t.Errorf("mint-back must be appended to isError results too, got %q", got)
+	if got := firstText(t, res); !strings.Contains(got, "session_id issued") {
+		t.Errorf("mint-back must be prepended to isError results too, got %q", got)
 	}
 	if evt.IsError == nil || !*evt.IsError {
 		t.Error("event must record the tool error")
@@ -109,7 +138,7 @@ func TestErrorResultsStillGetMintBack(t *testing.T) {
 		t.Errorf("error message must come from the result's text blocks, got %v", evt.Error)
 	}
 	// Wire-only: the decorated text must not become part of the recorded error.
-	if msg, _ := evt.Error["message"].(string); strings.Contains(msg, "MCP INSTRUCTIONS") {
+	if msg, _ := evt.Error["message"].(string); strings.Contains(msg, "[session_id") {
 		t.Errorf("mint-back leaked into the recorded error: %v", evt.Error)
 	}
 }
@@ -124,15 +153,15 @@ func TestMintBackReachesToolsThatReturnNoContent(t *testing.T) {
 
 	res, evt := h.call("structured_only", map[string]any{})
 
-	if got := lastText(t, res); !strings.Contains(got, "session_id issued") {
-		t.Errorf("mint-back must be appended to content-less results too, got %q", got)
+	if got := firstText(t, res); !strings.Contains(got, "session_id issued") {
+		t.Errorf("mint-back must be prepended to content-less results too, got %q", got)
 	}
-	if !strings.Contains(lastText(t, res), evt.GetSessionId()) {
+	if !strings.Contains(firstText(t, res), evt.GetSessionId()) {
 		t.Error("mint-back text does not name the event's session id")
 	}
 	// Wire-only: the published event carries the customer's original result.
 	resp := fmt.Sprint(evt.Response)
-	if strings.Contains(resp, "MCP INSTRUCTIONS") || strings.Contains(resp, "_mcp_instructions") {
+	if strings.Contains(resp, "[session_id") || strings.Contains(resp, "mcp_session") {
 		t.Errorf("decoration leaked into the published event response: %s", resp)
 	}
 }
@@ -152,37 +181,37 @@ func TestStructuredMirror(t *testing.T) {
 	if !ok {
 		t.Fatalf("structuredContent = %T, want a JSON object", res.StructuredContent)
 	}
-	mi, ok := sc["_mcp_instructions"].(map[string]any)
+	mi, ok := sc["mcp_session"].(map[string]any)
 	if !ok {
 		t.Fatalf("mirror missing from structuredContent: %v", sc)
 	}
 	if mi["session_id"] != sid("s") {
 		t.Errorf("mirror must re-confirm supplied handles on every response, got %v", mi["session_id"])
 	}
-	if instr, _ := mi["instructions"].(string); !strings.Contains(instr, "confirmed") {
-		t.Errorf("supplied handles get the confirmed copy, got %q", instr)
+	if status, _ := mi["status"].(string); status != "active" {
+		t.Errorf("supplied handles get the active status, got %q", status)
 	}
 	// The customer's own structured payload survives alongside the mirror.
 	if sc["text"] != "structured" {
 		t.Errorf("customer structured payload lost: %v", sc)
 	}
 	// Event purity: the published response carries no mirror.
-	if strings.Contains(fmt.Sprint(evt.Response), "_mcp_instructions") {
+	if strings.Contains(fmt.Sprint(evt.Response), "mcp_session") {
 		t.Error("mirror leaked into the published event")
 	}
 
 	// A minted call mirrors the new session with the full issued-session copy.
 	res2, evt2 := h.call("structured_only", map[string]any{})
 	sc2, _ := res2.StructuredContent.(map[string]any)
-	mi2, ok := sc2["_mcp_instructions"].(map[string]any)
+	mi2, ok := sc2["mcp_session"].(map[string]any)
 	if !ok {
 		t.Fatalf("mirror missing on minted call: %v", sc2)
 	}
 	if mi2["session_id"] != evt2.GetSessionId() {
 		t.Errorf("mirror session %v != event session %q", mi2["session_id"], evt2.GetSessionId())
 	}
-	if instr, _ := mi2["instructions"].(string); !strings.Contains(instr, "session_id issued") {
-		t.Errorf("minted mirror must carry the issued-session instructions, got %q", instr)
+	if status, _ := mi2["status"].(string); status != "issued" {
+		t.Errorf("minted mirror must carry the issued status, got %q", status)
 	}
 }
 
@@ -209,7 +238,7 @@ func TestStructuredMirrorPreservesNumbersOnTheWire(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal wire result: %v", err)
 	}
-	if !strings.Contains(string(wire), "_mcp_instructions") {
+	if !strings.Contains(string(wire), "mcp_session") {
 		t.Fatalf("mirror did not fire, so number fidelity is untested: %s", wire)
 	}
 	for _, want := range []string{
@@ -235,7 +264,7 @@ func TestNoMirrorForToolsWithoutDeclaredOutputSchema(t *testing.T) {
 	if !ok {
 		t.Fatalf("fixture must return structuredContent, got %T", res.StructuredContent)
 	}
-	if _, has := sc["_mcp_instructions"]; has {
+	if _, has := sc["mcp_session"]; has {
 		t.Error("mirror must be gated on the output-injection registry")
 	}
 }
@@ -266,7 +295,7 @@ func TestRegistriesRebuiltOnDemand(t *testing.T) {
 	if !ok {
 		t.Fatalf("fixture must return structuredContent, got %T", res.StructuredContent)
 	}
-	if _, has := sc["_mcp_instructions"]; has {
+	if _, has := sc["mcp_session"]; has {
 		t.Error("rebuilt registries must gate the mirror off for schema-less tools")
 	}
 }
@@ -291,12 +320,12 @@ func TestHookMode(t *testing.T) {
 	}
 	// No session instructions ever: neither text block nor structured mirror.
 	for _, c := range res.Content {
-		if tc, ok := c.(mcp.TextContent); ok && strings.Contains(tc.Text, "MCP INSTRUCTIONS") {
+		if tc, ok := c.(mcp.TextContent); ok && strings.Contains(tc.Text, "[session_id") {
 			t.Errorf("hook mode shows no session instructions ever, got %q", tc.Text)
 		}
 	}
 	if sc, ok := res.StructuredContent.(map[string]any); ok {
-		if _, has := sc["_mcp_instructions"]; has {
+		if _, has := sc["mcp_session"]; has {
 			t.Error("hook mode must not mirror handles")
 		}
 	}
@@ -329,7 +358,7 @@ func TestHookModeErrorMintsSilently(t *testing.T) {
 	}
 	// Silent means silent: no instructions reach the agent even for the mint.
 	for _, c := range res.Content {
-		if tc, ok := c.(mcp.TextContent); ok && strings.Contains(tc.Text, "MCP INSTRUCTIONS") {
+		if tc, ok := c.(mcp.TextContent); ok && strings.Contains(tc.Text, "[session_id") {
 			t.Errorf("hook mode shows no session instructions even on silent mint, got %q", tc.Text)
 		}
 	}
@@ -665,7 +694,7 @@ func TestDisableTracingNoMintBackNoEvents(t *testing.T) {
 		t.Error("context must still be stripped when tracing is disabled")
 	}
 	for _, c := range res.Content {
-		if tc, ok := c.(mcp.TextContent); ok && strings.Contains(tc.Text, "MCP INSTRUCTIONS") {
+		if tc, ok := c.(mcp.TextContent); ok && strings.Contains(tc.Text, "[session_id") {
 			t.Error("no mint-back when tracing is disabled")
 		}
 	}

--- a/mcpgo/integration_test.go
+++ b/mcpgo/integration_test.go
@@ -384,11 +384,10 @@ func TestErrorHandling_Integration(t *testing.T) {
 		t.Error("Expected error result content")
 	}
 
-	// Check if error message is present in result
-	if textContent, ok := result.Content[0].(mcp.TextContent); ok {
-		if !strings.Contains(textContent.Text, "not found") {
-			t.Errorf("Expected error message about not found, got: %s", textContent.Text)
-		}
+	// Check if error message is present in result (resultText skips the
+	// SDK's own leading mint-back block).
+	if text := resultText(result); !strings.Contains(text, "not found") {
+		t.Errorf("Expected error message about not found, got: %s", text)
 	}
 
 	// Note: OnError hook is called for actual errors, not tool error results
@@ -616,10 +615,8 @@ func TestTrack_HooksFireOnToolCall_Integration(t *testing.T) {
 		t.Fatalf("CallTool failed: %v", err)
 	}
 
-	if tc, ok := result.Content[0].(mcp.TextContent); ok {
-		if tc.Text != "Hello, World" {
-			t.Errorf("Expected 'Hello, World', got '%s'", tc.Text)
-		}
+	if text := resultText(result); text != "Hello, World" {
+		t.Errorf("Expected 'Hello, World', got '%s'", text)
 	}
 }
 

--- a/mcpgo/list_inject_test.go
+++ b/mcpgo/list_inject_test.go
@@ -54,8 +54,12 @@ func TestListInjectionAddsHandlesAndRegistries(t *testing.T) {
 			t.Errorf("missing injected param %s", p)
 		}
 	}
-	if containsStr(tool.InputSchema.Required, "session_id") {
-		t.Error("session_id must never be required")
+	if !containsStr(tool.InputSchema.Required, "session_id") {
+		t.Error("session_id must be required")
+	}
+	if sidProp, _ := tool.InputSchema.Properties["session_id"].(map[string]any); sidProp == nil ||
+		sidProp["pattern"] != "^(start|ses_[0-9A-Za-z]{27})$" {
+		t.Errorf("session_id must declare its value pattern, got %v", tool.InputSchema.Properties["session_id"])
 	}
 	if !containsStr(tool.InputSchema.Required, "agent_id") {
 		t.Error("agent_id must be required when agent tracking is on")

--- a/mcpgo/registered_input_schema_test.go
+++ b/mcpgo/registered_input_schema_test.go
@@ -45,8 +45,8 @@ func TestClosedInputSchemaAcceptsInjectedParams(t *testing.T) {
 			t.Fatalf("advertised schema for echo_args is missing %s: %s", want, advertised)
 		}
 	}
-	if !strings.Contains(advertised, `"required":["context"]`) {
-		t.Fatalf("advertised schema must mark context required: %s", advertised)
+	if !strings.Contains(advertised, `"required":["session_id","context"]`) {
+		t.Fatalf("advertised schema must mark session_id and context required: %s", advertised)
 	}
 
 	result, evt := h.call("echo_args", map[string]any{

--- a/mcpgo/registered_schema.go
+++ b/mcpgo/registered_schema.go
@@ -33,7 +33,7 @@ import (
 //   - OUTPUT: mcp-go validates a result against the registered output schema
 //     AFTER the middleware has run (server/server.go:2021), and
 //     mcp.WithOutputSchema[T] emits "additionalProperties": false, so the
-//     structured mirror needs `_mcp_instructions` declared there.
+//     structured mirror needs `mcp_session` declared there.
 //
 // A declared property satisfies a closed schema, so `additionalProperties` is
 // deliberately left exactly as the customer set it on both halves.

--- a/mcpgo/registered_schema_test.go
+++ b/mcpgo/registered_schema_test.go
@@ -47,7 +47,7 @@ func newValidatingServer(t *testing.T) *server.MCPServer {
 }
 
 // TestMirrorSurvivesOutputSchemaValidation is the regression pin for the
-// closed-output-schema break: the mirror adds _mcp_instructions to
+// closed-output-schema break: the mirror adds mcp_session to
 // structuredContent, and mcp-go validates the decorated result against the
 // tool's REGISTERED output schema, so that property must be declared there.
 func TestMirrorSurvivesOutputSchemaValidation(t *testing.T) {
@@ -64,7 +64,7 @@ func TestMirrorSurvivesOutputSchemaValidation(t *testing.T) {
 	if !ok {
 		t.Fatalf("structuredContent = %T, want a JSON object", res.StructuredContent)
 	}
-	mi, ok := sc["_mcp_instructions"].(map[string]any)
+	mi, ok := sc["mcp_session"].(map[string]any)
 	if !ok {
 		t.Fatalf("mirror missing from structuredContent: %v", sc)
 	}
@@ -75,7 +75,7 @@ func TestMirrorSurvivesOutputSchemaValidation(t *testing.T) {
 		t.Errorf("customer payload lost: %v", sc)
 	}
 	// Wire-only: the published event carries the undecorated result.
-	if strings.Contains(fmt.Sprint(evt.Response), "_mcp_instructions") {
+	if strings.Contains(fmt.Sprint(evt.Response), "mcp_session") {
 		t.Errorf("mirror leaked into the published event: %v", evt.Response)
 	}
 }
@@ -94,8 +94,8 @@ func TestRegisteredOutputSchemaDeclaresMirror(t *testing.T) {
 	schema := marshalRegisteredOutputSchema(t, registered.Tool)
 
 	props, _ := schema["properties"].(map[string]any)
-	if _, has := props["_mcp_instructions"]; !has {
-		t.Errorf("registered output schema must declare _mcp_instructions: %v", schema)
+	if _, has := props["mcp_session"]; !has {
+		t.Errorf("registered output schema must declare mcp_session: %v", schema)
 	}
 	if _, has := props["text"]; !has {
 		t.Errorf("customer properties must survive: %v", schema)
@@ -105,8 +105,8 @@ func TestRegisteredOutputSchemaDeclaresMirror(t *testing.T) {
 	}
 	required, _ := schema["required"].([]any)
 	for _, name := range required {
-		if name == "_mcp_instructions" {
-			t.Error("_mcp_instructions must be optional, never required")
+		if name == "mcp_session" {
+			t.Error("mcp_session must be optional, never required")
 		}
 	}
 
@@ -174,7 +174,7 @@ func TestRegisteredOutputSchemaDeclarationIsIdempotent(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("call failed after repeated declaration passes: %q", resultText(res))
 	}
-	if sc, ok := res.StructuredContent.(map[string]any); !ok || sc["_mcp_instructions"] == nil {
+	if sc, ok := res.StructuredContent.(map[string]any); !ok || sc["mcp_session"] == nil {
 		t.Errorf("mirror stopped firing after repeated passes: %v", res.StructuredContent)
 	}
 }
@@ -233,20 +233,20 @@ func TestLiveRegisteredTools_ReadsPrivateToolState(t *testing.T) {
 }
 
 // TestCustomerDeclaredInstructionsPropertyIsPreserved pins that a customer who
-// already declares _mcp_instructions keeps their own definition.
+// already declares mcp_session keeps their own definition.
 func TestCustomerDeclaredInstructionsPropertyIsPreserved(t *testing.T) {
-	const customerSchema = `{"type":"object","properties":{"text":{"type":"string"},"_mcp_instructions":{"type":"string","description":"mine"}}}`
+	const customerSchema = `{"type":"object","properties":{"text":{"type":"string"},"mcp_session":{"type":"string","description":"mine"}}}`
 
 	mcpServer := server.NewMCPServer("customer-owned-server", "1.0.0",
 		server.WithToolCapabilities(true),
 	)
 	mcpServer.AddTool(
 		mcp.NewTool("owns_instructions",
-			mcp.WithDescription("Declares _mcp_instructions itself"),
+			mcp.WithDescription("Declares mcp_session itself"),
 			mcp.WithRawOutputSchema(json.RawMessage(customerSchema)),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			return &mcp.CallToolResult{StructuredContent: map[string]any{"text": "t", "_mcp_instructions": "mine"}}, nil
+			return &mcp.CallToolResult{StructuredContent: map[string]any{"text": "t", "mcp_session": "mine"}}, nil
 		},
 	)
 
@@ -255,15 +255,15 @@ func TestCustomerDeclaredInstructionsPropertyIsPreserved(t *testing.T) {
 
 	schema := marshalRegisteredOutputSchema(t, mcpServer.ListTools()["owns_instructions"].Tool)
 	props, _ := schema["properties"].(map[string]any)
-	own, _ := props["_mcp_instructions"].(map[string]any)
+	own, _ := props["mcp_session"].(map[string]any)
 	if own["description"] != "mine" {
-		t.Errorf("customer's own _mcp_instructions definition must win: %v", props)
+		t.Errorf("customer's own mcp_session definition must win: %v", props)
 	}
 
 	res, _ := h.call("owns_instructions", map[string]any{"session_id": sid("c")})
 	sc, _ := res.StructuredContent.(map[string]any)
-	if sc["_mcp_instructions"] != "mine" {
-		t.Errorf("customer's own value must win at runtime, got %v", sc["_mcp_instructions"])
+	if sc["mcp_session"] != "mine" {
+		t.Errorf("customer's own value must win at runtime, got %v", sc["mcp_session"])
 	}
 }
 
@@ -322,7 +322,7 @@ func TestSessionScopedToolGetsMirrorDeclaration(t *testing.T) {
 	if !ok {
 		t.Fatalf("structuredContent = %T, want a JSON object", res.StructuredContent)
 	}
-	if _, has := sc["_mcp_instructions"]; !has {
+	if _, has := sc["mcp_session"]; !has {
 		t.Errorf("session-scoped tools must mirror handles too: %v", sc)
 	}
 	if sc["text"] != "session payload" {
@@ -339,11 +339,11 @@ func TestSessionScopedToolGetsMirrorDeclaration(t *testing.T) {
 }
 
 // TestCustomerTypedInstructionsPropertyIsNotMirrored pins the unpopulated
-// case: a customer who declares `_mcp_instructions` with a shape of their own
+// case: a customer who declares `mcp_session` with a shape of their own
 // must not have AgentCat's object written into it. Doing so would violate their
 // declared schema — under output validation the call would fail outright.
 func TestCustomerTypedInstructionsPropertyIsNotMirrored(t *testing.T) {
-	const customerSchema = `{"type":"object","properties":{"text":{"type":"string"},"_mcp_instructions":{"type":"string"}},"additionalProperties":false}`
+	const customerSchema = `{"type":"object","properties":{"text":{"type":"string"},"mcp_session":{"type":"string"}},"additionalProperties":false}`
 
 	mcpServer := server.NewMCPServer("customer-typed-server", "1.0.0",
 		server.WithToolCapabilities(true),
@@ -351,7 +351,7 @@ func TestCustomerTypedInstructionsPropertyIsNotMirrored(t *testing.T) {
 	)
 	mcpServer.AddTool(
 		mcp.NewTool("typed_instructions",
-			mcp.WithDescription("Declares _mcp_instructions as a string and never fills it"),
+			mcp.WithDescription("Declares mcp_session as a string and never fills it"),
 			mcp.WithRawOutputSchema(json.RawMessage(customerSchema)),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -370,7 +370,7 @@ func TestCustomerTypedInstructionsPropertyIsNotMirrored(t *testing.T) {
 	if !ok {
 		t.Fatalf("structuredContent = %T, want a JSON object", res.StructuredContent)
 	}
-	if _, has := sc["_mcp_instructions"]; has {
+	if _, has := sc["mcp_session"]; has {
 		t.Errorf("AgentCat must not fill a property the customer typed itself: %v", sc)
 	}
 }

--- a/mcpgo/resource_prompt_test.go
+++ b/mcpgo/resource_prompt_test.go
@@ -335,10 +335,8 @@ func TestResourceAndPromptTracking_WithToolCalls(t *testing.T) {
 	if len(addResult.Content) == 0 {
 		t.Fatal("Expected add_todo to return content")
 	}
-	if tc, ok := addResult.Content[0].(mcp.TextContent); ok {
-		if !strings.Contains(tc.Text, "Added todo") {
-			t.Errorf("Expected add_todo result to contain 'Added todo', got: %s", tc.Text)
-		}
+	if text := resultText(addResult); !strings.Contains(text, "Added todo") {
+		t.Errorf("Expected add_todo result to contain 'Added todo', got: %s", text)
 	}
 
 	// 3. List resources

--- a/mcpgo/schema_passthrough_test.go
+++ b/mcpgo/schema_passthrough_test.go
@@ -78,7 +78,7 @@ func TestUnparseableOutputSchemaIsAdvertisedUntouched(t *testing.T) {
 
 	res, _ := h.call("opaque_output", map[string]any{"session_id": sid("o")})
 	sc, _ := res.StructuredContent.(map[string]any)
-	if _, has := sc["_mcp_instructions"]; has {
+	if _, has := sc["mcp_session"]; has {
 		t.Errorf("a schema the SDK cannot read must not be mirrored into: %v", sc)
 	}
 }

--- a/mcpgo/test_helpers_test.go
+++ b/mcpgo/test_helpers_test.go
@@ -436,16 +436,17 @@ func (h *spyHarness) listTools() *mcp.ListToolsResult {
 	return result
 }
 
-// lastText returns the text of the final content block of a result.
-func lastText(t *testing.T, result *mcp.CallToolResult) string {
+// firstText returns the text of the FIRST content block of a result — the
+// position where this SDK prepends its mint-back block.
+func firstText(t *testing.T, result *mcp.CallToolResult) string {
 	t.Helper()
 	if result == nil || len(result.Content) == 0 {
 		t.Fatal("result has no content")
 	}
-	last := result.Content[len(result.Content)-1]
-	tc, ok := last.(mcp.TextContent)
+	first := result.Content[0]
+	tc, ok := first.(mcp.TextContent)
 	if !ok {
-		t.Fatalf("last content block is %T, want mcp.TextContent", last)
+		t.Fatalf("first content block is %T, want mcp.TextContent", first)
 	}
 	return tc.Text
 }
@@ -488,14 +489,21 @@ func listToolRawJSON(t *testing.T, mcpServer *server.MCPServer, toolName string)
 	return ""
 }
 
-// resultText extracts the text from the first TextContent entry in a
-// CallToolResult. It returns an empty string when no text content is found.
+// resultText extracts the text of the first TextContent entry in a
+// CallToolResult that is not this SDK's own leading mint-back block, so
+// assertions about the CUSTOMER's text hold whether or not the call was
+// decorated. It returns an empty string when no such content is found.
 func resultText(result *mcp.CallToolResult) string {
-	if result == nil || len(result.Content) == 0 {
+	if result == nil {
 		return ""
 	}
-	if tc, ok := result.Content[0].(mcp.TextContent); ok {
-		return tc.Text
+	for _, c := range result.Content {
+		if tc, ok := c.(mcp.TextContent); ok {
+			if isMintBackText(tc.Text) {
+				continue
+			}
+			return tc.Text
+		}
 	}
 	return ""
 }
@@ -559,10 +567,9 @@ func sid(label string) string {
 	return "ses_" + (b.String() + strings.Repeat("0", 27))[:27]
 }
 
-// mintBackFor renders the [MCP INSTRUCTIONS] block this SDK appends on the
-// call that minted sessionID. Tests assert against the real generator rather
-// than a copied literal, so a copy change cannot pass here and fail on the
-// wire.
+// mintBackFor renders the text block this SDK prepends on the call that
+// minted sessionID. Tests assert against the real generator rather than a
+// copied literal, so a copy change cannot pass here and fail on the wire.
 func mintBackFor(sessionID string) string {
 	return agentcat.BuildMintBackText(agentcat.SessionResolution{
 		SessionID: sessionID,

--- a/mcpgo/validation_test.go
+++ b/mcpgo/validation_test.go
@@ -126,7 +126,7 @@ func TestCustomerOwnedSessionParamIsForeign(t *testing.T) {
 		t.Errorf("session source tag = %q, want foreign", got)
 	}
 	raw, _ := json.Marshal(res)
-	if strings.Contains(string(raw), "MCP INSTRUCTIONS") || strings.Contains(string(raw), "_mcp_instructions") {
+	if strings.Contains(string(raw), "[session_id") || strings.Contains(string(raw), "mcp_session") {
 		t.Errorf("AgentCat must say nothing about a parameter that is not ours: %s", raw)
 	}
 }
@@ -211,7 +211,7 @@ func TestInvalidCorrectionReachesTheAgentOnly(t *testing.T) {
 	// The agent is corrected, on the wire.
 	var corrected bool
 	for _, c := range res.Content {
-		if tc, ok := c.(mcp.TextContent); ok && strings.Contains(tc.Text, "session_id not recognized") {
+		if tc, ok := c.(mcp.TextContent); ok && strings.Contains(tc.Text, "[session_id unrecognized") {
 			corrected = true
 		}
 	}
@@ -221,7 +221,7 @@ func TestInvalidCorrectionReachesTheAgentOnly(t *testing.T) {
 
 	// The event carries the customer's original response only.
 	resp := fmt.Sprint(evt.Response)
-	if strings.Contains(resp, "not recognized") || strings.Contains(resp, "MCP INSTRUCTIONS") {
+	if strings.Contains(resp, "unrecognized") || strings.Contains(resp, "[session_id") {
 		t.Errorf("the correction leaked into the published event: %s", resp)
 	}
 }
@@ -234,8 +234,8 @@ func TestUndecorateStripsTheCorrection(t *testing.T) {
 		agentcat.SessionResolution{Source: agentcat.SessionSourceInvalid})
 
 	decorated := &mcp.CallToolResult{Content: []mcp.Content{
-		mcp.NewTextContent("the customer's own answer"),
 		mcp.NewTextContent(correction),
+		mcp.NewTextContent("the customer's own answer"),
 	}}
 	got := undecorateResult(decorated)
 	if len(got.Content) != 1 {
@@ -247,10 +247,71 @@ func TestUndecorateStripsTheCorrection(t *testing.T) {
 
 	// A customer block that merely mentions the phrase is NOT ours to remove.
 	customer := &mcp.CallToolResult{Content: []mcp.Content{
-		mcp.NewTextContent("my docs explain that session_id not recognized means retry"),
+		mcp.NewTextContent("my docs explain that session_id unrecognized means retry"),
 	}}
 	if len(undecorateResult(customer).Content) != 1 {
 		t.Error("undecoration must only remove blocks it can rebuild byte-for-byte")
+	}
+}
+
+// TestUndecorateStripsMintedDecorationAndMirror pins the full round-trip for
+// the decoration decorateResult writes today: the minted block at the FIRST
+// content position and the {session_id, agent_id, status} mirror. Both must be
+// rebuilt and removed so the published event carries the customer's original
+// result; a mirror this SDK could not have built must survive untouched.
+func TestUndecorateStripsMintedDecorationAndMirror(t *testing.T) {
+	id := sid("undecorate")
+	minted := agentcat.BuildMintBackText(
+		agentcat.SessionResolution{SessionID: id, Source: agentcat.SessionSourceMinted})
+
+	decorated := &mcp.CallToolResult{
+		Content: []mcp.Content{
+			mcp.NewTextContent(minted),
+			mcp.NewTextContent("the customer's own answer"),
+		},
+		StructuredContent: map[string]any{
+			"text": "payload",
+			"mcp_session": map[string]any{
+				"session_id": id,
+				"agent_id":   "opus|cc|k3n9x",
+				"status":     "issued",
+			},
+		},
+	}
+
+	got := undecorateResult(decorated)
+	if len(got.Content) != 1 {
+		t.Fatalf("undecoration left %d blocks, want 1: %+v", len(got.Content), got.Content)
+	}
+	if tc, ok := got.Content[0].(mcp.TextContent); !ok || tc.Text != "the customer's own answer" {
+		t.Errorf("undecoration removed the wrong block: %+v", got.Content[0])
+	}
+	sc, ok := got.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("structuredContent = %T, want a JSON object", got.StructuredContent)
+	}
+	if _, has := sc["mcp_session"]; has {
+		t.Errorf("the mirror must be removed: %v", sc)
+	}
+	if sc["text"] != "payload" {
+		t.Errorf("customer structured payload must survive: %v", sc)
+	}
+
+	// The hook/foreign shape — agent_id alone — is ours too.
+	agentOnly := &mcp.CallToolResult{StructuredContent: map[string]any{
+		"mcp_session": map[string]any{"agent_id": "opus|cc|k3n9x"},
+	}}
+	if sc, ok := undecorateResult(agentOnly).StructuredContent.(map[string]any); !ok || sc["mcp_session"] != nil {
+		t.Errorf("the agent-only mirror must be removed: %v", sc)
+	}
+
+	// A near-miss this SDK never builds (issued session named with the wrong
+	// status) is not provably ours and must be left alone.
+	nearMiss := &mcp.CallToolResult{StructuredContent: map[string]any{
+		"mcp_session": map[string]any{"session_id": id, "status": "confirmed"},
+	}}
+	if sc, ok := undecorateResult(nearMiss).StructuredContent.(map[string]any); !ok || sc["mcp_session"] == nil {
+		t.Error("a mirror this SDK could not have built must survive undecoration")
 	}
 }
 

--- a/officialsdk/concurrency_test.go
+++ b/officialsdk/concurrency_test.go
@@ -131,8 +131,8 @@ func TestParallelCallsMintDistinctSessions(t *testing.T) {
 	clientSession, _, mock := setupStreamableHTTP(t, nil)
 
 	type outcome struct {
-		payload  string
-		lastText string
+		payload   string
+		firstText string
 	}
 	results := make([]outcome, parallelCalls)
 
@@ -154,12 +154,12 @@ func TestParallelCallsMintDistinctSessions(t *testing.T) {
 				t.Errorf("call %d returned no content", i)
 				return
 			}
-			tc, ok := res.Content[len(res.Content)-1].(*mcp.TextContent)
+			tc, ok := res.Content[0].(*mcp.TextContent)
 			if !ok {
-				t.Errorf("call %d: last content block is %T", i, res.Content[len(res.Content)-1])
+				t.Errorf("call %d: first content block is %T", i, res.Content[0])
 				return
 			}
-			results[i] = outcome{payload: payload, lastText: tc.Text}
+			results[i] = outcome{payload: payload, firstText: tc.Text}
 		}()
 	}
 	wg.Wait()
@@ -195,8 +195,8 @@ func TestParallelCallsMintDistinctSessions(t *testing.T) {
 			t.Errorf("no event for call %d", i)
 			continue
 		}
-		if want := mintBackFor(session); got.lastText != want {
-			t.Errorf("call %d got mint-back %q, want %q", i, got.lastText, want)
+		if want := mintBackFor(session); got.firstText != want {
+			t.Errorf("call %d got mint-back %q, want %q", i, got.firstText, want)
 		}
 	}
 }

--- a/officialsdk/factory_e2e_test.go
+++ b/officialsdk/factory_e2e_test.go
@@ -144,7 +144,7 @@ func TestFactoryTopologyRebuildOnDemand(t *testing.T) {
 	if !strings.HasPrefix(minted, "ses_") {
 		t.Fatalf("expected a minted ses_ session, got %q", minted)
 	}
-	if got := lastText(t, res); got != mintBackFor(minted) {
+	if got := firstText(t, res); got != mintBackFor(minted) {
 		t.Errorf("mint-back missing or wrong on the rebuilt instance:\n got:  %q\n want: %q",
 			got, mintBackFor(minted))
 	}
@@ -207,7 +207,7 @@ func TestFactoryTopologyRebuildGatesTheMirror(t *testing.T) {
 	if !ok {
 		t.Fatalf("structured content = %T, want map", res.StructuredContent)
 	}
-	if _, has := sc[agentcat.MCPInstructionsKey]; has {
+	if _, has := sc[agentcat.MCPSessionKey]; has {
 		t.Error("structured_only declares no output schema: the rebuilt registry must keep the mirror off")
 	}
 	if sc["ok"] != true {
@@ -261,9 +261,11 @@ func decodeEchoedArgs(t *testing.T, res *mcp.CallToolResult) map[string]any {
 	if len(res.Content) == 0 {
 		t.Fatal("echo_args returned no content")
 	}
-	tc, ok := res.Content[0].(*mcp.TextContent)
+	// The customer's own text is the LAST block (a mint-back, when present,
+	// is prepended as the first).
+	tc, ok := res.Content[len(res.Content)-1].(*mcp.TextContent)
 	if !ok {
-		t.Fatalf("echo content = %T, want *mcp.TextContent", res.Content[0])
+		t.Fatalf("echo content = %T, want *mcp.TextContent", res.Content[len(res.Content)-1])
 	}
 	var echoed map[string]any
 	if err := json.Unmarshal([]byte(tc.Text), &echoed); err != nil {

--- a/officialsdk/go.mod
+++ b/officialsdk/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0
-	go.agentcat.com/sdk/v2 v2.0.0
+	go.agentcat.com/sdk/v2 v2.1.0
 )
 
 require (

--- a/officialsdk/handles_test.go
+++ b/officialsdk/handles_test.go
@@ -55,7 +55,8 @@ func callToolOn(t *testing.T, cs *mcp.ClientSession, mock *mockPublisher, name s
 	return res, events[before]
 }
 
-// lastText returns the text of the final content block of a result.
+// lastText returns the text of the final content block of a result — where
+// the customer's own text sits once this SDK prepends its mint-back block.
 func lastText(t *testing.T, res *mcp.CallToolResult) string {
 	t.Helper()
 	if len(res.Content) == 0 {
@@ -64,6 +65,20 @@ func lastText(t *testing.T, res *mcp.CallToolResult) string {
 	tc, ok := res.Content[len(res.Content)-1].(*mcp.TextContent)
 	if !ok {
 		t.Fatalf("last content block is %T, want *mcp.TextContent", res.Content[len(res.Content)-1])
+	}
+	return tc.Text
+}
+
+// firstText returns the text of the FIRST content block of a result — the
+// position where this SDK prepends its mint-back block.
+func firstText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	if len(res.Content) == 0 {
+		t.Fatal("result has no content")
+	}
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("first content block is %T, want *mcp.TextContent", res.Content[0])
 	}
 	return tc.Text
 }
@@ -108,16 +123,17 @@ func TestCallMintsSessionAndMintsBack(t *testing.T) {
 		"context": "adding my first todo",
 	})
 
-	// 1. The wire response carries the trailing mint-back text block…
-	if got := lastText(t, res); !strings.HasPrefix(got, "[MCP INSTRUCTIONS]: session_id issued.") {
-		t.Errorf("missing mint-back block, last content = %q", got)
+	// 1. The wire response carries the leading mint-back text block as its
+	// FIRST content element…
+	if got := firstText(t, res); !strings.HasPrefix(got, "[session_id issued") {
+		t.Errorf("missing mint-back block, first content = %q", got)
 	}
 	// …and the published event does NOT (wire-only discipline).
 	resp := fmt.Sprint(evt.Response)
-	if strings.Contains(resp, "MCP INSTRUCTIONS") {
+	if strings.Contains(resp, "[session_id") {
 		t.Errorf("mint-back leaked into the published event response: %s", resp)
 	}
-	if strings.Contains(resp, "_mcp_instructions") {
+	if strings.Contains(resp, "mcp_session") {
 		t.Errorf("mirror leaked into the published event response: %s", resp)
 	}
 
@@ -129,7 +145,7 @@ func TestCallMintsSessionAndMintsBack(t *testing.T) {
 	if evt.Tags == nil || (*evt.Tags)["agentcat_session_id_source"] != "minted" {
 		t.Errorf("session source tag missing or wrong: %v", evt.Tags)
 	}
-	if !strings.Contains(lastText(t, res), evt.GetSessionId()) {
+	if !strings.Contains(firstText(t, res), evt.GetSessionId()) {
 		t.Error("mint-back text does not name the event's session id")
 	}
 
@@ -149,6 +165,29 @@ func TestCallMintsSessionAndMintsBack(t *testing.T) {
 	_, evt2 := callToolOn(t, cs, mock, "add_todo", map[string]any{"title": "again", "context": "x"})
 	if evt2.GetSessionId() == evt.GetSessionId() {
 		t.Error("two mint calls must mint distinct sessions (stateless per call)")
+	}
+}
+
+// TestStartSentinelMintsLikeOmission pins the start value's contract: it
+// resolves exactly like a first call that sent nothing — mint, issued block —
+// and the literal value is never adopted as a session.
+func TestStartSentinelMintsLikeOmission(t *testing.T) {
+	server, _, mock := createFullTestServerWithTracking(t, nil)
+	cs := connectClient(t, server)
+
+	res, evt := callToolOn(t, cs, mock, "add_todo", map[string]any{"title": "hi", "session_id": "start"})
+	if got := firstText(t, res); !strings.HasPrefix(got, "[session_id issued") {
+		t.Errorf("start must be issued a session, first content = %q", got)
+	}
+	if !strings.HasPrefix(evt.GetSessionId(), "ses_") {
+		t.Errorf("sessionId = %q, want a minted ses_ id", evt.GetSessionId())
+	}
+	if evt.Tags == nil || (*evt.Tags)["agentcat_session_id_source"] != "minted" {
+		t.Errorf("session source tag must be minted, got %v", evt.Tags)
+	}
+	args, _ := evt.Parameters["arguments"].(map[string]any)
+	if args["session_id"] != "start" {
+		t.Errorf("raw arguments must record the sentinel, got %v", args)
 	}
 }
 
@@ -183,8 +222,8 @@ func TestErrorResultsStillGetMintBack(t *testing.T) {
 	if !res.IsError {
 		t.Fatal("fixture tool must return an IsError result")
 	}
-	if got := lastText(t, res); !strings.Contains(got, "session_id issued") {
-		t.Errorf("mint-back must be appended to isError results too, got %q", got)
+	if got := firstText(t, res); !strings.Contains(got, "session_id issued") {
+		t.Errorf("mint-back must be prepended to isError results too, got %q", got)
 	}
 	if evt.IsError == nil || !*evt.IsError {
 		t.Error("event must record the tool error")
@@ -202,15 +241,15 @@ func TestMintBackReachesToolsThatReturnNoContent(t *testing.T) {
 
 	res, evt := callToolOn(t, cs, mock, "structured_only", map[string]any{})
 
-	if got := lastText(t, res); !strings.Contains(got, "session_id issued") {
-		t.Errorf("mint-back must be appended to content-less results too, got %q", got)
+	if got := firstText(t, res); !strings.Contains(got, "session_id issued") {
+		t.Errorf("mint-back must be prepended to content-less results too, got %q", got)
 	}
-	if !strings.Contains(lastText(t, res), evt.GetSessionId()) {
+	if !strings.Contains(firstText(t, res), evt.GetSessionId()) {
 		t.Error("mint-back text does not name the event's session id")
 	}
 	// Wire-only: the published event carries the customer's original result.
 	resp := fmt.Sprint(evt.Response)
-	if strings.Contains(resp, "MCP INSTRUCTIONS") || strings.Contains(resp, "_mcp_instructions") {
+	if strings.Contains(resp, "[session_id") || strings.Contains(resp, "mcp_session") {
 		t.Errorf("decoration leaked into the published event response: %s", resp)
 	}
 }
@@ -233,37 +272,37 @@ func TestStructuredMirror(t *testing.T) {
 	if !ok {
 		t.Fatalf("structuredContent = %T, want a JSON object", res.StructuredContent)
 	}
-	mi, ok := sc["_mcp_instructions"].(map[string]any)
+	mi, ok := sc["mcp_session"].(map[string]any)
 	if !ok {
 		t.Fatalf("mirror missing from structuredContent: %v", sc)
 	}
 	if mi["session_id"] != sid("s") {
 		t.Errorf("mirror must re-confirm supplied handles on every response, got %v", mi["session_id"])
 	}
-	if instr, _ := mi["instructions"].(string); !strings.Contains(instr, "confirmed") {
-		t.Errorf("supplied handles get the confirmed copy, got %q", instr)
+	if status, _ := mi["status"].(string); status != "active" {
+		t.Errorf("supplied handles get the active status, got %q", status)
 	}
 	// The customer's own structured payload survives alongside the mirror.
 	if sc["text"] == nil {
 		t.Errorf("customer structured payload lost: %v", sc)
 	}
 	// Event purity: the published response carries no mirror.
-	if strings.Contains(fmt.Sprint(evt.Response), "_mcp_instructions") {
+	if strings.Contains(fmt.Sprint(evt.Response), "mcp_session") {
 		t.Error("mirror leaked into the published event")
 	}
 
 	// A minted call mirrors the new session with the full issued-session copy.
 	res2, evt2 := callToolOn(t, cs, mock, "add_todo", map[string]any{"title": "y"})
 	sc2, _ := res2.StructuredContent.(map[string]any)
-	mi2, ok := sc2["_mcp_instructions"].(map[string]any)
+	mi2, ok := sc2["mcp_session"].(map[string]any)
 	if !ok {
 		t.Fatalf("mirror missing on minted call: %v", sc2)
 	}
 	if mi2["session_id"] != evt2.GetSessionId() {
 		t.Errorf("mirror session %v != event session %q", mi2["session_id"], evt2.GetSessionId())
 	}
-	if instr, _ := mi2["instructions"].(string); !strings.Contains(instr, "session_id issued") {
-		t.Errorf("minted mirror must carry the issued-session instructions, got %q", instr)
+	if status, _ := mi2["status"].(string); status != "issued" {
+		t.Errorf("minted mirror must carry the issued status, got %q", status)
 	}
 }
 
@@ -303,7 +342,7 @@ func TestStructuredMirrorPreservesNumbersOnTheWire(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal wire result: %v", err)
 	}
-	if !strings.Contains(string(wire), "_mcp_instructions") {
+	if !strings.Contains(string(wire), "mcp_session") {
 		t.Fatalf("mirror did not fire, so number fidelity is untested: %s", wire)
 	}
 	for _, want := range []string{
@@ -330,7 +369,7 @@ func TestNoMirrorForToolsWithoutDeclaredOutputSchema(t *testing.T) {
 	res, _ := callToolOn(t, cs, mock, "echo_args", map[string]any{"payload": "p", "context": "c"})
 	if res.StructuredContent != nil {
 		if sc, ok := res.StructuredContent.(map[string]any); ok {
-			if _, has := sc["_mcp_instructions"]; has {
+			if _, has := sc["mcp_session"]; has {
 				t.Error("mirror must be gated on the output-injection registry")
 			}
 		}
@@ -358,12 +397,12 @@ func TestHookMode(t *testing.T) {
 	}
 	// No session instructions ever: neither text block nor structured mirror.
 	for _, c := range res.Content {
-		if tc, ok := c.(*mcp.TextContent); ok && strings.Contains(tc.Text, "MCP INSTRUCTIONS") {
+		if tc, ok := c.(*mcp.TextContent); ok && strings.Contains(tc.Text, "[session_id") {
 			t.Errorf("hook mode shows no session instructions ever, got %q", tc.Text)
 		}
 	}
 	if sc, ok := res.StructuredContent.(map[string]any); ok {
-		if _, has := sc["_mcp_instructions"]; has {
+		if _, has := sc["mcp_session"]; has {
 			t.Error("hook mode must not mirror handles")
 		}
 	}
@@ -402,7 +441,7 @@ func TestHookModeErrorMintsSilently(t *testing.T) {
 	}
 	// Silent means silent: no instructions reach the agent even for the mint.
 	for _, c := range res.Content {
-		if tc, ok := c.(*mcp.TextContent); ok && strings.Contains(tc.Text, "MCP INSTRUCTIONS") {
+		if tc, ok := c.(*mcp.TextContent); ok && strings.Contains(tc.Text, "[session_id") {
 			t.Errorf("hook mode shows no session instructions even on silent mint, got %q", tc.Text)
 		}
 	}
@@ -633,12 +672,12 @@ func TestDisableTracingNoMintBackNoEvents(t *testing.T) {
 		t.Fatal("call must succeed with tracing disabled")
 	}
 	for _, c := range res.Content {
-		if tc, ok := c.(*mcp.TextContent); ok && strings.Contains(tc.Text, "MCP INSTRUCTIONS") {
+		if tc, ok := c.(*mcp.TextContent); ok && strings.Contains(tc.Text, "[session_id") {
 			t.Error("no mint-back when tracing is disabled")
 		}
 	}
 	if sc, ok := res.StructuredContent.(map[string]any); ok {
-		if _, has := sc["_mcp_instructions"]; has {
+		if _, has := sc["mcp_session"]; has {
 			t.Error("no mirror when tracing is disabled")
 		}
 	}

--- a/officialsdk/list_inject_test.go
+++ b/officialsdk/list_inject_test.go
@@ -119,8 +119,12 @@ func TestListInjectionAddsHandlesAndRegistries(t *testing.T) {
 		}
 	}
 	required := stringSlice(schema["required"])
-	if containsStr(required, "session_id") {
-		t.Error("session_id must never be required")
+	if !containsStr(required, "session_id") {
+		t.Error("session_id must be required")
+	}
+	if sidProp, _ := props["session_id"].(map[string]any); sidProp == nil ||
+		sidProp["pattern"] != "^(start|ses_[0-9A-Za-z]{27})$" {
+		t.Errorf("session_id must declare its value pattern, got %v", props["session_id"])
 	}
 	if !containsStr(required, "agent_id") {
 		t.Error("agent_id must be required when agent tracking is on")

--- a/officialsdk/middleware.go
+++ b/officialsdk/middleware.go
@@ -259,28 +259,30 @@ func decorateResult(
 	cp := *res
 	cp.Content = append([]mcp.Content(nil), res.Content...)
 
-	// (a) Trailing text block: on the call that minted a new session, and on
+	// (a) Leading text block: on the call that minted a new session, and on
 	// one that sent a session_id this server never issued. BuildMintBackText
 	// owns that decision — hook mode, foreign and supplied all return "".
-	// Applied unconditionally otherwise: to error results (the retry after an
-	// error must carry the same session) and to tools that return no content
-	// at all (structured-only tools would otherwise never learn their session,
-	// and every call would mint a fresh one).
+	// Prepended as the FIRST content element: IDs at the end of long responses
+	// can be truncated away by clients. Applied unconditionally otherwise: to
+	// error results (the retry after an error must carry the same session) and
+	// to tools that return no content at all (structured-only tools would
+	// otherwise never learn their session, and every call would mint a fresh
+	// one).
 	if text := agentcat.BuildMintBackText(resolution); text != "" {
-		cp.Content = append(cp.Content, &mcp.TextContent{Text: text})
+		cp.Content = append([]mcp.Content{&mcp.TextContent{Text: text}}, cp.Content...)
 	}
 
 	// (b) Structured mirror: persistent handle state on every response,
 	// gated on the output-injection registry, plain-object structuredContent
-	// only, customer's own _mcp_instructions key wins.
+	// only, customer's own mcp_session key wins.
 	mirror := agentcat.BuildHandleMirror(agentcat.MirrorInput{
 		Resolution: resolution,
 		AgentID:    agentID,
 	})
 	if mirror != nil && agentcat.ShouldMirror(toolName, reg) {
 		if sc, ok := structuredContentAsMap(res.StructuredContent); ok {
-			if _, customerOwns := sc[agentcat.MCPInstructionsKey]; !customerOwns {
-				sc[agentcat.MCPInstructionsKey] = mirror
+			if _, customerOwns := sc[agentcat.MCPSessionKey]; !customerOwns {
+				sc[agentcat.MCPSessionKey] = mirror
 				cp.StructuredContent = sc
 			}
 		}

--- a/officialsdk/middleware_test.go
+++ b/officialsdk/middleware_test.go
@@ -200,9 +200,10 @@ func TestMiddleware_ToolCall_CreatesEvent(t *testing.T) {
 	if len(result.Content) == 0 {
 		t.Fatal("expected non-empty content")
 	}
-	if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+	if tc, ok := result.Content[len(result.Content)-1].(*mcp.TextContent); ok {
 		// With mcp.AddTool(), the typed result struct is JSON-serialized.
-		// (The v2 mint-back block is appended AFTER the customer content.)
+		// (The v2 mint-back block is prepended BEFORE the customer content,
+		// so the customer's text is the last block.)
 		if tc.Text != `{"text":"Hello, World!"}` {
 			t.Errorf("expected '{\"text\":\"Hello, World!\"}', got '%s'", tc.Text)
 		}
@@ -666,8 +667,8 @@ func TestStructuredContentAsMap(t *testing.T) {
 	if !ok {
 		t.Fatal("map input must convert")
 	}
-	got["_mcp_instructions"] = "mirror"
-	if _, leaked := orig["_mcp_instructions"]; leaked {
+	got["mcp_session"] = "mirror"
+	if _, leaked := orig["mcp_session"]; leaked {
 		t.Error("conversion must copy: the customer's structuredContent was mutated")
 	}
 }
@@ -733,7 +734,7 @@ func TestMiddleware_GetMoreTools_Call(t *testing.T) {
 	if len(result.Content) == 0 {
 		t.Fatal("expected non-empty content")
 	}
-	if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+	if tc, ok := result.Content[len(result.Content)-1].(*mcp.TextContent); ok {
 		if !strings.Contains(tc.Text, "full tool list") {
 			t.Errorf("expected response to mention full tool list, got '%s'", tc.Text)
 		}

--- a/officialsdk/mrtr_handles_test.go
+++ b/officialsdk/mrtr_handles_test.go
@@ -60,7 +60,7 @@ func TestMRTRInputRequiredTagsAndSkipsDecoration(t *testing.T) {
 		t.Error("input-required results must pass through undecorated (same object)")
 	}
 	for _, c := range got.Content {
-		if tc, ok := c.(*mcp.TextContent); ok && strings.Contains(tc.Text, "MCP INSTRUCTIONS") {
+		if tc, ok := c.(*mcp.TextContent); ok && strings.Contains(tc.Text, "[session_id") {
 			t.Error("no mint-back on MRTR intermediate results")
 		}
 	}

--- a/officialsdk/schema_passthrough_test.go
+++ b/officialsdk/schema_passthrough_test.go
@@ -72,9 +72,11 @@ func decodeEchoed(t *testing.T, result *mcp.CallToolResult) map[string]any {
 	if len(result.Content) == 0 {
 		t.Fatal("echo tool returned no content")
 	}
-	tc, ok := result.Content[0].(*mcp.TextContent)
+	// The customer's own text is the LAST block (a mint-back, when present,
+	// is prepended as the first).
+	tc, ok := result.Content[len(result.Content)-1].(*mcp.TextContent)
 	if !ok {
-		t.Fatalf("echo tool content is %T, want *mcp.TextContent", result.Content[0])
+		t.Fatalf("echo tool content is %T, want *mcp.TextContent", result.Content[len(result.Content)-1])
 	}
 	var echoed map[string]any
 	if err := json.Unmarshal([]byte(tc.Text), &echoed); err != nil {
@@ -140,7 +142,7 @@ func TestUnparseableSchemaIsAdvertisedUntouched(t *testing.T) {
 		t.Fatalf("CallTool: %v", err)
 	}
 	if sc, ok := res.StructuredContent.(map[string]any); ok {
-		if _, has := sc["_mcp_instructions"]; has {
+		if _, has := sc["mcp_session"]; has {
 			t.Errorf("a schema the SDK cannot read must not be mirrored into: %v", sc)
 		}
 	}
@@ -265,7 +267,7 @@ func TestTrackIsIdempotentPerServer(t *testing.T) {
 	// Exactly one mint-back block on the wire, not two.
 	mintBacks := 0
 	for _, block := range res.Content {
-		if tc, ok := block.(*mcp.TextContent); ok && strings.Contains(tc.Text, "[MCP INSTRUCTIONS]") {
+		if tc, ok := block.(*mcp.TextContent); ok && strings.Contains(tc.Text, "[session_id") {
 			mintBacks++
 		}
 	}

--- a/officialsdk/stdio_e2e_test.go
+++ b/officialsdk/stdio_e2e_test.go
@@ -461,7 +461,7 @@ func TestStdio_GetMoreTools(t *testing.T) {
 	if len(result.Content) == 0 {
 		t.Fatal("expected non-empty content")
 	}
-	if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+	if tc, ok := result.Content[len(result.Content)-1].(*mcp.TextContent); ok {
 		if !strings.Contains(tc.Text, "full tool list") {
 			t.Errorf("expected response to mention full tool list, got '%s'", tc.Text)
 		}

--- a/officialsdk/streamable_http_e2e_test.go
+++ b/officialsdk/streamable_http_e2e_test.go
@@ -460,7 +460,7 @@ func TestHTTP_StatelessSharedServer(t *testing.T) {
 	if !strings.HasPrefix(minted, "ses_") {
 		t.Errorf("expected a minted ses_ session, got %q", minted)
 	}
-	if got := lastText(t, res); got != mintBackFor(minted) {
+	if got := firstText(t, res); got != mintBackFor(minted) {
 		t.Errorf("stateless mint-back = %q, want %q", got, mintBackFor(minted))
 	}
 	if evt.UserIntent == nil || *evt.UserIntent != "why" {
@@ -606,7 +606,7 @@ func TestHTTP_GetMoreTools(t *testing.T) {
 	if len(result.Content) == 0 {
 		t.Fatal("expected non-empty content")
 	}
-	if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+	if tc, ok := result.Content[len(result.Content)-1].(*mcp.TextContent); ok {
 		if !strings.Contains(tc.Text, "full tool list") {
 			t.Errorf("expected response to mention full tool list, got '%s'", tc.Text)
 		}

--- a/officialsdk/test_helpers_test.go
+++ b/officialsdk/test_helpers_test.go
@@ -25,7 +25,7 @@ func sid(label string) string {
 	return "ses_" + (b.String() + strings.Repeat("0", 27))[:27]
 }
 
-// mintBackFor renders the [MCP INSTRUCTIONS] block this SDK appends on the
+// mintBackFor renders the text block this SDK prepends on the
 // call that minted sessionID. Tests assert against the real generator rather
 // than a copied literal, so a copy change cannot pass here and fail on the
 // wire.

--- a/officialsdk/validation_test.go
+++ b/officialsdk/validation_test.go
@@ -95,15 +95,15 @@ func TestInvalidSessionPublishesSessionless(t *testing.T) {
 		t.Errorf("raw arguments must still record what the agent sent, got %v", args)
 	}
 	// The agent is corrected on the wire...
-	if got := lastText(t, res); !strings.Contains(got, "session_id not recognized") {
-		t.Errorf("the agent was not corrected; last content = %q", got)
+	if got := firstText(t, res); !strings.Contains(got, "[session_id unrecognized") {
+		t.Errorf("the agent was not corrected; first content = %q", got)
 	}
 	// ...and the correction never reaches the published event.
-	if resp := fmt.Sprint(evt.Response); strings.Contains(resp, "not recognized") {
+	if resp := fmt.Sprint(evt.Response); strings.Contains(resp, "unrecognized") {
 		t.Errorf("the correction leaked into the published event: %s", resp)
 	}
 	// It must hand out NO replacement handle.
-	if strings.Contains(lastText(t, res), "session_id=ses_") {
+	if strings.Contains(firstText(t, res), "ses_") {
 		t.Error("the correction must not issue a replacement handle")
 	}
 }
@@ -155,7 +155,7 @@ func TestCustomerOwnedSessionParamIsForeign(t *testing.T) {
 	}
 	// Silence: no correction, no mint-back, no mirror.
 	raw, _ := json.Marshal(res)
-	if strings.Contains(string(raw), "MCP INSTRUCTIONS") || strings.Contains(string(raw), "_mcp_instructions") {
+	if strings.Contains(string(raw), "[session_id") || strings.Contains(string(raw), "mcp_session") {
 		t.Errorf("AgentCat must say nothing about a parameter that is not ours: %s", raw)
 	}
 }

--- a/types.go
+++ b/types.go
@@ -78,9 +78,9 @@ const (
 	ParamAgentID   = constants.ParamAgentID
 	ParamContext   = constants.ParamContext
 
-	// MCPInstructionsKey is the structuredContent member carrying the handle
+	// MCPSessionKey is the structuredContent member carrying the handle
 	// mirror, and the property declared on extended output schemas.
-	MCPInstructionsKey = constants.MCPInstructionsKey
+	MCPSessionKey = constants.MCPSessionKey
 
 	// MetaClientInfoKey and MetaProtocolVersionKey are the reserved _meta keys
 	// a 2026-07-28 client stamps on every request.
@@ -209,7 +209,7 @@ func StripToolArguments(toolName string, args map[string]any, reg *Registries) m
 	return inject.Strip(toolName, args, reg)
 }
 
-// BuildHandleMirror assembles the _mcp_instructions value mirrored into a
+// BuildHandleMirror assembles the mcp_session value mirrored into a
 // response's structuredContent. Returns nil when there is nothing the agent
 // could echo back.
 func BuildHandleMirror(in MirrorInput) map[string]any { return inject.BuildMirror(in) }


### PR DESCRIPTION
Session handles are easy for callers to miss when they arrive at the tail of a long result — clients that truncate large tool outputs can drop the issuance notice entirely, and agents then start new sessions instead of continuing the one they were given. This change makes the handle mechanism sturdier and easier for agents to consume:

- **IDs are issued at the start of the response.** The issuance text block is now the first content element instead of the last, so it survives client-side truncation of long results.
- **`session_id` and `agent_id` are now required parameters with an explicit value contract.** `session_id` takes one of two values — the `ses_` ID issued for the task, or the literal `start` to begin a new one — declared with a validation pattern in the schema (`^(start|ses_[0-9A-Za-z]{27})$`). Every call states its session explicitly, so sessions never split by accident. Servers keep accepting calls that omit the parameters (treated as the start of a new task), so requiredness is enforced only by schema-aware clients — the registered schema used by mcp-go's opt-in input-schema validation deliberately keeps the injected parameters optional (pinned by `TestRegisteredInputDeclarationKeepsCustomerContract`), so nothing existing breaks server-side.
- **`mcp_session` replaces `_mcp_instructions`** as the structured mirror in `structuredContent`, declared in each tool's output schema. It carries a machine-readable `status` enum (`issued` / `active` / `unrecognized`) instead of prose — every response state an agent can encounter is pre-announced in the schema.
- **Leaner, self-describing parameter copy.** The `session_id` and `agent_id` descriptions now explain the mechanism in terms of what this server does, pre-announce both text-block headers so responses match the schema's stated contract, and collapse the two `agent_id` description variants into one.
- **Recovery is explicit.** An unrecognized value is reported both as `mcp_session.status: "unrecognized"` and as a leading text block, with the recovery path (re-send the earlier ID, or send `start` if none was issued) stated in the schema.

**Breaking wire changes** (for consumers that assert on response internals or schemas): the `structuredContent` mirror key is renamed `_mcp_instructions` → `mcp_session`; its `instructions` string member is removed in favor of `status`; the issuance text block moved from the last to the first content position and its header text changed (`[session_id issued …]` / `[session_id unrecognized …]`); `session_id` and `agent_id` now appear in each tool's `required` array alongside `context`, and `session_id` declares the validation pattern above.

Version bumped to 2.1.0.

**Testing**
- `make check` (fmt + vet + root tests): all passed
- `make test-mcpgo`, `make test-officialsdk`: ok (`-race`)
- `make build-examples`: all five examples build

Cross-SDK note: this lands the same strings and wire shape in all three SDKs, byte-identical where applicable. Sibling PRs: https://github.com/agentcathq/agentcat-typescript-sdk/pull/67 · https://github.com/agentcathq/agentcat-python-sdk/pull/53
